### PR TITLE
Add not found ID tests for tasks

### DIFF
--- a/backend/app/controllers/tasks_controller.rb
+++ b/backend/app/controllers/tasks_controller.rb
@@ -23,9 +23,9 @@ class TasksController < ApplicationController
   
     def update
       if @task.update(task_params)
-        render json: @task
+        render json: @task, status: :ok
       else
-        render json: @task.errors, status: :unprocessable_entity
+        render json: { errors: @task.errors.full_messages }, status: :unprocessable_entity
       end
     end
   
@@ -35,13 +35,14 @@ class TasksController < ApplicationController
     end
   
     private
-  
+
     def set_task
-      @task = Task.find(params[:id])
+      @task = Task.find(params[:id]) # IDでタスクを検索
+    rescue ActiveRecord::RecordNotFound # 該当するタスクが存在しない場合は例外をキャッチ
+        render json: { errors: ["Task not found"]}, status: :not_found # JSON形式でエラーレスポンスを返し、HTTPステーステータスを404にする
     end
-  
+
     def task_params
-      params.require(:task).permit(:title, :description, :status, :deadline, :user_id)
+      params.require(:task).permit(:title, :status, :user_id)
     end
-  end
-  
+end

--- a/backend/spec/requests/tasks_spec.rb
+++ b/backend/spec/requests/tasks_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe "Task API", type: :request do
     end
 
 
-
     describe "PATCH /tasks/:id" do
         it "タスクを更新できる" do
             user = User.create!(email: "test3@example.com", password: "password")
@@ -81,6 +80,20 @@ RSpec.describe "Task API", type: :request do
         end
     end
 
+    # PATCH /tasks/:id (異常系)
+    describe "PATCH /tasks/:id(異常系)" do
+        it "存在しないIDなら404を返す" do
+            patch "/tasks/999999", params: {
+                task: { title: "更新後タスク" }
+            }
+
+            expect(response).to have_http_status(:not_found)
+            json = JSON.parse(response.body)
+            expect(json["errors"]).to include("Task not found")
+        end
+    end
+
+
     describe "DELETE /tasks/:id" do
         it "タスクを削除できる" do
             user = User.create!(email: "test4@example.com", password: "password")
@@ -92,6 +105,15 @@ RSpec.describe "Task API", type: :request do
             expect(Task.find_by(id: task.id)).to be_nil
         end
     end
+
+    # DELETE /tasks/:id (異常系)
+    describe "DELETE /tasks/:id (異常系)" do
+        it "存在しないIDなら404を返す" do
+            delete "/tasks/999999"
+
+            expect(response).to have_http_status(:not_found)
+            json = JSON.parse(response.body)
+            expect(json["errors"]).to include("Task not found")
+        end
+    end
 end
-
-


### PR DESCRIPTION
存在しないID指定時に404を返すリクエストスペックを追加しました。
- PATCH /tasks/:id
- DELETE /tasks/:id
