### PR TITLE
Refactor: RSpec request specs for tasks (shared_examples, let, before)

### DIFF
--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -69,4 +69,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
 end

--- a/backend/spec/requests/tasks_spec.rb
+++ b/backend/spec/requests/tasks_spec.rb
@@ -1,14 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe "Task API", type: :request do
-    include Devise::Test::IntegrationHelpers  # ←追加
+    include Devise::Test::IntegrationHelpers # Deviseのログインヘルパー (sign_in, sign_outなど) を利用可能にする
 
-    # GET /tasks
+    # ---- テスト共有ユーザー ---- #
+    let(:user) { User.create!(email: "test@example.com", password: "password") }
+
+    # ---- 共通レスポンス分析 ---- #
+    def json
+        JSON.parse(response.body)
+    end
+
+    # ---- 共有テストパターン(shared_examples) ---- #
+    shared_examples "unauthorized request" do
+        it "401を返す" do
+            expect(response).to have_http_status(:unauthorized)
+            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
+        end
+    end
+
+    shared_examples "not found request" do
+        it "404を返す" do
+            expect(response).to have_http_status(:not_found)
+            expect(json["errors"]).to include("Task not found")
+        end
+    end
+
+
+
+
+    # ---- GET /tasks ----#
     describe "GET /tasks" do
         it "タスク一覧を取得できる" do
             # テストデータ作成
-            user = User.create!(email: "test@example.com", password: "password")
-
             Task.create!(title: "テストタスク1", status: :not_started, user: user)
             Task.create!(title: "テストタスク2", status: :in_progress, user: user)
 
@@ -17,18 +41,16 @@ RSpec.describe "Task API", type: :request do
 
             # レスポンスの検証
             expect(response).to have_http_status(:ok) # ステータスコード200(OK)？
-            json = JSON.parse(response.body) # JSON文字列をRubyハッシュに変換
             expect(json.size).to eq(2) # APIレスポンスで帰ってきたタスク配列の要素が２つか検証
             expect(json[0]["title"]).to eq("テストタスク1") # 1つ目のタスクタイトルが「テストタスク1」か？
         end
     end
 
-    # GET /tasks (関連データ：ユーザーごと)
+    # ---- GET /tasks (ユーザーごとのスコープ) ----#
     describe "GET /tasks (ユーザーごとのスコープ)" do
         it "指定したユーザーのタスクだけ取得できる" do
             user1 = User.create!(email: "user1@example.com", password: "password")
             user2 = User.create!(email: "user2@example.com", password: "password")
-
             Task.create!(title: "user1のタスク1", status: :not_started, user: user1)
             Task.create!(title: "user1のタスク2", status: :completed, user: user1)
             Task.create!(title: "user2のタスク", status: :in_progress, user: user2)
@@ -36,161 +58,118 @@ RSpec.describe "Task API", type: :request do
             get "/tasks", params: { user_id: user1.id } # user1のタスクだけ取得するようにAPIリクエストを送る
 
             expect(response).to have_http_status(:ok) # HTTPステータスが200(OK)であることを確認
-
-            json = JSON.parse(response.body) # JSONレスポンスをパースして配列化
-            expect(json.size).to eq(2) # 取得したタスク数が２件だけであることを確認
             titles = json.map { |task| task["title"]} # タスクのタイトル一覧を配列に抽出
             expect(titles).to include("user1のタスク1", "user1のタスク2") # user1のタスクが含まれていることを確認
-
             expect(titles).not_to include("user2のタスク") # user2のタスクが含まれていないことを確認
         end
     end
 
-
-    # タスク生成テスト
+    # ---- POST/ tasks (タスクを作成できる) ----#
     describe "POST /tasks()" do
         it "タスクを作成できる" do
-          user = User.create!(email: "test2@example.com", password: "password")
-          sign_in user  # ← ログイン状態を再現
+          sign_in user.reload  # ← ログイン状態を再現
           post "/tasks", params: { task: { 
             title: "新しいタスク", 
             status: :not_started, 
           } }
       
-          expect(response).to have_http_status(:created)
-          json = JSON.parse(response.body)
-          expect(json["title"]).to eq("新しいタスク")
-          expect(json["user_id"]).to eq(user.id)
+          expect(response).to have_http_status(:created) # ステータス201
+          expect(json["title"]).to eq("新しいタスク") # 作成したタスクのタイトルが一致
         end
-    end
-      
-      # バリデーションテスト (異常系:タイトルが空の場合)
-      describe "POST /tasks (異常系)" do
-        it "タイトルが空なら422を返す" do
-            # テスト用ユーザーを作成
-            user = User.create!(email: "test@example.com", password: "password")
-            sign_in user
 
+        # ---- バリデーションテスト (異常系:タイトルが空の場合)
+        it "タイトルが空なら422を返す" do
+            sign_in user.reload
             # APIにタスク作成リクエストを送信 (タイトルが空)
             post "/tasks", params: {
                 task: {
                     title: "", # バリデーションに引っ掛かる値
                     status: :not_started, # enumのステータス
-                    user_id: user.id # 関連付けるユーザー
                 }
             }
-
             # HTTPステータスコードの確認
             # コントローラ側で422を返すように実装している前提
             expect(response).to have_http_status(:unprocessable_entity)
-            json = JSON.parse(response.body) # レスポンスのJSONをパース
             # エラーメッセージがレスポンスに含まれているか確認
             expect(json["errors"]).to include("Title can't be blank")
         end
-    end
-
-    # POST /tasks (認証必須)
-    describe "POST /tasks (認証必須)" do
-        it "未ログインの場合401を返す" do
+        
+        # ---- POST /tasks (認証必須)
+        context "未ログインの場合401を返す" do
             # ログインせずにタスク作成APIを叩く
-            post "/tasks", params: {
+            before { post "/tasks", params: { 
                 task: {
                     title: "未ログインタスク",
-                    status: :not_started,
-                    user_id: 1 # 指定しているが認証必須なので無視される想定
+                    status: :not_started
                 }
-            }
-
-            expect(response).to have_http_status(:unauthorized)
-            json = JSON.parse(response.body)
-            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
+            }}
+            it_behaves_like "unauthorized request"
         end
     end
 
+    # ---- PATCH /tasks/:id ---- #
     describe "PATCH /tasks/:id" do
         it "タスクを更新できる" do
-            user = User.create!(email: "test3@example.com", password: "password")
-            sign_in user
+            sign_in user.reload
             task = Task.create!(title: "更新前タスク", status: :not_started, user: user)
 
             patch "/tasks/#{task.id}", params: { task: { title: "更新後タスク" } }
 
-            expect(response).to have_http_status(:ok)
-            json = JSON.parse(response.body)
-            expect(json["title"]).to eq("更新後タスク")
+            expect(response).to have_http_status(:ok) # ステータス201
+            expect(json["title"]).to eq("更新後タスク") # タイトルが更新後の内容になる
         end
-    end
 
-    # PATCH /tasks/:id (異常系)
-    describe "PATCH /tasks/:id(異常系)" do
-        it "存在しないIDなら404を返す" do
-            user = User.create!(email: "patchtest@example.com", password: "password")
-            sign_in user
-            patch "/tasks/999999", params: {
-                task: { title: "更新後タスク" }
+        # ---- PATCH /tasks/:id (異常系)
+        context "存在しないIDなら404を返す" do
+            before do
+                sign_in user.reload
+                patch "/tasks/999999", params: {
+                    task: { title: "更新後タスク" }
+                }
+            end
+            it_behaves_like "not found request"
+        end
+
+        # ---- PATCH /tasks/:id (認証必須) 
+        context "未ログインの場合401を返す" do
+            let(:task) { 
+                Task.create!(
+                    title: "ログイン必須タスク",
+                    status: :not_started,
+                    user: user
+                )
             }
-
-            expect(response).to have_http_status(:not_found)
-            json = JSON.parse(response.body)
-            expect(json["errors"]).to include("Task not found")
+            before { patch "/tasks/#{task.id}"}
+            it_behaves_like "unauthorized request"
         end
     end
-
-    # PATCH /tasks/:id (認証必須)
-    describe "PATCH /tasks/:id (認証必須)" do
-        it "未ログインの場合401を返す" do
-            user = User.create!(email: "patchtest@example.com", password: "password")
-            task = Task.create!(title: "未ログイン更新タスク", status: :not_started, user: user)
-            # ログインせずにPATCHリクエストを送信
-            patch "/tasks/#{task.id}", params: {
-                task: { title: "未ログインで更新" }
-            }
-            # HTTPステータスが401(Unauthorized)であることを確認
-            expect(response).to have_http_status(:unauthorized)
-            json = JSON.parse(response.body)
-            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
-        end
-    end
-
+    
+    # ---- DELETE /tasks/:id ---- #
     describe "DELETE /tasks/:id" do
         it "タスクを削除できる" do
-            user = User.create!(email: "test4@example.com", password: "password")
-            sign_in user
+            sign_in user.reload
             task = Task.create!(title: "削除タスク", status: :not_started, user: user)
-
+            
             delete "/tasks/#{task.id}"
 
-            expect(response).to have_http_status(:no_content)
-            expect(Task.find_by(id: task.id)).to be_nil
+            expect(response).to have_http_status(:no_content) # ステータス204
+            expect(Task.find_by(id: task.id)).to be_nil # DBから削除されていること
+        end
+
+        # ---- DELETE /tasks/:id (異常系)
+        context "存在しないIDなら404を返す" do
+            before do
+                sign_in user.reload
+                delete "/tasks/999999"
+            end
+            it_behaves_like "not found request"
+        end
+
+        # ---- DELETE /tasks/:id (認証必須)
+        context "未ログインの場合401を返す" do
+            let(:task) { Task.create!(title: "未ログイン削除タスク", status: :not_started, user: user) }
+            before { delete "/tasks/#{task.id}" }
+            it_behaves_like "unauthorized request"
         end
     end
-
-    # DELETE /tasks/:id (異常系)
-    describe "DELETE /tasks/:id (異常系)" do
-        it "存在しないIDなら404を返す" do
-            user = User.create!(email: "test4@example.com", password: "password")
-            sign_in user
-            delete "/tasks/999999"
-
-            expect(response).to have_http_status(:not_found)
-            json = JSON.parse(response.body)
-            expect(json["errors"]).to include("Task not found")
-        end
-    end
-
-    # DELETE /tasks/:id (認証必須)
-    describe "DELETE /tasks/:id (認証必須)" do
-        it "未ログインの場合401を返す" do
-            user = User.create!(email: "deletetest@example.com", password: "password")
-            task = Task.create!(title: "未ログイン削除タスク",status: :not_started, user: user)
-
-            # ログインせずにDELETEリクエストを送信
-            delete "/tasks/#{task.id}"
-
-            expect(response).to have_http_status(:unauthorized) # HTTPステータスが401(Unauthorized)であることを確認
-            json = JSON.parse(response.body)
-            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
-        end
-    end
-
 end


### PR DESCRIPTION
・shared_examples, let, beforeを使用してテストコードを整理
・不要なsign_inを削除
