### PR TITLE
子タスクの変更で親タスクの進捗率(progress)を自動更新する機能を追加

### DIFF
--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -1,9 +1,33 @@
 class Task < ApplicationRecord
   belongs_to :user
 
+  belongs_to :parent, class_name: 'Task', optional: true
+  has_many :children, class_name: 'Task', foreign_key: 'parent_id', dependent: :destroy
+
   # 進捗ステータス(0:未着手, 1:進行中, 2:完了)
   enum :status, { not_started: 0, in_progress: 1, completed: 2 }, prefix: true
 
   validates :title, presence: true
   validates :status, presence: true
+
+  after_update :update_progress_if_needed
+
+  def update_parent_progress
+    return unless children.exists?
+  
+    completed_count = children.status_completed.count
+    total_count = children.count
+    new_progress = (completed_count.to_f / total_count * 100).round(1)
+  
+    update!(progress: new_progress)
+  end
+  
+
+  private
+
+  def update_progress_if_needed
+    if saved_change_to_status? || saved_change_to_parent_id?
+      parent&.update_parent_progress
+    end
+  end
 end


### PR DESCRIPTION
子タスクの status または parent_id が変更された際に、親タスクの progress を自動で更新する機能を追加しました。

変更点
・Task モデルに after_update コールバックを追加

・status または parent_id に変更があった場合に、親タスクの update_parent_progress を実行

・update_parent_progress メソッドで、完了している子タスク数を元に progress を再計算