### PR TITLE
Add dummy task list UI with TaskCard component

### DIFF
--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,0 +1,22 @@
+type Task = {
+    id: number;
+    title: string;
+    dueDate: string;
+    status: string;
+};
+
+type Props = {
+    task: Task;
+};
+
+const TaskCard = ({ task }: Props) => {
+    return (
+        <div className="border rounded p-4 shadow-sm bg-white mb-4">
+            <h2 className="text-lg font-semibold">{task.title}</h2>
+            <p className="text-sm text-gray-600">期限: {task.dueDate}</p>
+            <p className="text-sm text-gray-600">ステータス: {task.status}</p>
+        </div>
+    );
+};
+
+export default TaskCard

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,9 +1,20 @@
+import TaskCard from "../components/TaskCard"
+
 const TaskList = () => {
+    const dummyTasks = [
+        { id: 1, title: '工程会議の資料作成', dueDate: '2025-08-10', status: '未着手' },
+        { id: 2, title: '現場写真の撮影', dueDate: '2025-08-06', status: '進行中'},
+        { id: 3, title: '材料検収の報告書', dueDate: '2025-08-05', status: '完了'},
+    ];
+
     return (
     <div>
-        <h1 className="text-2xl font-bold text-green-500">タスク一覧ページ</h1>
+        <h1 className="text-2xl font-bold mb-6">タスク一覧ページ</h1>
+        {dummyTasks.map((task) => (
+            <TaskCard key={task.id} task={task} />
+        ))}
     </div>
-    )
-}
+    );
+};
 
-export default TaskList
+export default TaskList;


### PR DESCRIPTION
概要
タスク一覧ページ（/tasks）のダミーUIを実装

TaskCardコンポーネントを作成し、モックデータを表示

🛠 変更点
pages/TaskList.tsx にタスク一覧のレイアウトを追加

components/TaskCard.tsx を新規作成し、タスク情報を表示

Tailwind CSS を使った簡易デザイン適用済み

📌 補足
現段階ではバックエンドとの接続は未実装

今後、API連携や並び替え機能などを順次追加予定