### PR TITLE
タスク一覧を再帰的に表示（子タスク対応）

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -35,6 +35,7 @@ gem "thruster", require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
+gem 'rack-cors'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -214,6 +214,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -390,6 +393,7 @@ DEPENDENCIES
   kamal
   omniauth (~> 2.0)
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.2)
   rspec-rails
   rubocop-rails-omakase

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,16 +1,11 @@
-# Be sure to restart your server when you modify this file.
-
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
-
-# Read more: https://github.com/cyu/rack-cors
-
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins 'http://localhost:5173'
+  
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :put, :patch, :delete, :options, :head],
+        credentials: true
+    end
+  end
+  


### PR DESCRIPTION
概要
タスク一覧ページで、親タスクに紐づく子タスクも再帰的に表示されるように対応しました。

変更点
Rails側で as_tree メソッドによりタスクを階層構造で返却

React側で TaskItem コンポーネントを再帰的にレンダリング

型定義を更新（Task 型に children を追加）