### PR TITLE
chore: Tailwind 読み込み順とテンプレCSSを整理（レイアウト安定化）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
         "postcss": "^8.5.6",
-        "tailwindcss": "^3.4.1",
+        "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4"
@@ -3236,13 +3236,16 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3716,19 +3719,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/postcss-load-config/node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/postcss-nested": {
@@ -4214,34 +4204,34 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
-      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
+        "chokidar": "^3.6.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.3.0",
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
-        "lilconfig": "^2.1.0",
-        "micromatch": "^4.0.5",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.1",
-        "postcss-nested": "^6.0.1",
-        "postcss-selector-parser": "^6.0.11",
-        "resolve": "^1.22.2",
-        "sucrase": "^3.32.0"
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.1",
+    "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4"

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -3,4 +3,4 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/frontend/src/features/priority/PriorityTasksPanel.tsx
+++ b/frontend/src/features/priority/PriorityTasksPanel.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 function formatDeadline(iso?: string | null) {
   if (!iso) return "期限なし";
   const d = new Date(iso);
-  const w = ["日","月","火","水","木","金","土"][d.getDay()];
+  const w = ["日", "月", "火", "水", "木", "金", "土"][d.getDay()];
   return `${d.getMonth() + 1}/${d.getDate()}(${w})`;
 }
 
@@ -30,19 +30,22 @@ function DueBadge({ deadline }: { deadline?: string | null }) {
 
 export default function PriorityTasksPanel() {
   const { data, isLoading, isError } = usePriorityTasks();
+  const items = data ?? [];
 
   return (
-    <section className="bg-white rounded-2xl shadow p-4">
+    // ← 右カラム化：幅・境界線・独立スクロール
+    <div className="bg-white rounded-2xl shadow p-4">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-lg font-semibold">今日の優先タスク</h2>
-        <Link to="/tasks" className="text-sm underline">
-          すべて見る
-        </Link>
+        <h2 className="text-lg font-semibold">全体の優先タスク</h2>
+        {/* 件数バッジ */}
+        <span className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700">
+          {items.length}件
+        </span>
       </div>
 
       {isLoading && (
         <ul className="space-y-2">
-          {[...Array(3)].map((_, i) => (
+          {[...Array(5)].map((_, i) => (
             <li key={i} className="h-12 bg-gray-100 animate-pulse rounded" />
           ))}
         </ul>
@@ -52,33 +55,48 @@ export default function PriorityTasksPanel() {
         <p className="text-sm text-red-600">読み込みに失敗しました</p>
       )}
 
-      {data && data.length === 0 && (
+      {!isLoading && !isError && items.length === 0 && (
         <p className="text-sm text-gray-500">優先タスクはありません</p>
       )}
 
-      {data && data.length > 0 && (
+      {!isLoading && !isError && items.length > 0 && (
         <ul className="space-y-3">
-          {data.map((t) => (
-            <li key={t.id} className="border rounded-xl p-3 hover:bg-gray-50">
-              <div className="flex items-start justify-between">
-                <Link to={`/tasks/${t.id}`} className="font-medium line-clamp-1">
-                  {t.title}
-                </Link>
-                <DueBadge deadline={t.deadline} />
-              </div>
-              <div className="text-xs text-gray-600 mt-1">
-                {formatDeadline(t.deadline)} ・ 進捗 {t.progress}%
-              </div>
-              <div className="w-full bg-gray-200 h-2 rounded mt-2">
-                <div
-                  className="h-2 rounded bg-gray-700"
-                  style={{ width: `${t.progress}%` }}
-                />
-              </div>
-            </li>
-          ))}
+          {items.map((t) => {
+            const progress = t.progress ?? 0;
+            return (
+              <li key={t.id} className="border rounded-xl p-3 hover:bg-gray-50">
+                <div className="flex items-start justify-between">
+                  <Link
+                    to={`/tasks/${t.id}`}
+                    className="font-medium line-clamp-1"
+                  >
+                    {t.title}
+                  </Link>
+                  <DueBadge deadline={t.deadline} />
+                </div>
+                <div className="text-xs text-gray-600 mt-1">
+                  {formatDeadline(t.deadline)} ・ 進捗 {progress}%
+                </div>
+                <div className="w-full bg-gray-200 h-2 rounded mt-2">
+                  <div
+                    className="h-2 rounded bg-gray-700"
+                    style={{
+                      width: `${Math.min(Math.max(progress, 0), 100)}%`,
+                    }}
+                  />
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
-    </section>
+
+      {/* 補助リンク（任意） */}
+      <div className="mt-4 text-right">
+        <Link to="/tasks" className="text-xs underline text-gray-700">
+          タスク一覧へ
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/features/priority/usePriorityTasks.ts
+++ b/frontend/src/features/priority/usePriorityTasks.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import type { Task } from "../../types/task";
+import { api } from "../../lib/apiClient"
 
 async function getPriorityTasks(): Promise<Task[]> {
-  const res = await axios.get<Task[]>("/api/tasks/priority");
-  return res.data;
+    const { data } = await api.get<Task[]>("/api/tasks/priority");
+    return data;
 }
 
 export function usePriorityTasks() {
@@ -12,5 +12,8 @@ export function usePriorityTasks() {
     queryKey: ["priorityTasks"],
     queryFn: getPriorityTasks,
     retry: false,
+    staleTime: 30_000,
+    gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* 任意：全体余白やフォント調整など */
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+export const api = axios.create({ baseURL: "/" });
+
+api.interceptors.request.use((config) => {
+  // 認証トークンを付与する場合はここ
+  // const token = localStorage.getItem("access-token");
+  // if (token) config.headers['access-token'] = token;
+  return config;
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "./index.css"
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,3 +1,4 @@
+// src/pages/TaskList.tsx
 import { useEffect, useState } from "react";
 import axios from "axios";
 import TaskItem from "../components/TaskItem";
@@ -17,7 +18,7 @@ export default function TaskList() {
       })
       .catch((err) => {
         console.error("タスク取得失敗:", err);
-        setTasks([]); // 保険
+        setTasks([]);
       });
   }, []);
 
@@ -25,18 +26,19 @@ export default function TaskList() {
     <div className="max-w-6xl mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">タスク一覧ページ</h1>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
-        {/* 右カラム：優先タスク（小画面＝先頭 / LG以上＝右） */}
-        <aside className="order-1 lg:order-2 lg:col-span-1 sticky top-4 self-start">
-          <PriorityTasksPanel />
-        </aside>
-
-        {/* 左カラム：一覧（小画面＝後ろ / LG以上＝左） */}
-        <section className="order-2 lg:order-1 lg:col-span-2 space-y-3">
+      {/* ★ここをflex 2カラムに変更 */}
+      <div className="flex gap-6 items-start">
+        {/* 左：タスク一覧（可変） */}
+        <section className="flex-1 space-y-3">
           {tasks.map((task) => (
             <TaskItem key={task.id} task={task} />
           ))}
         </section>
+
+        {/* 右：優先タスク（固定幅） */}
+        <aside className="w-[22rem] shrink-0 sticky top-4 self-start pl-4 border-l">
+          <PriorityTasksPanel />
+        </aside>
       </div>
     </div>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,8 +4,6 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
-  theme: {
-    extend: {},
-  },
+  theme: { extend: {} },
   plugins: [],
-}
+};


### PR DESCRIPTION
## 目的
タスク一覧ページに「全体の優先タスク」を右カラムで常時表示し、締切の近い/超過タスクを視認しやすくする。

## 変更点
- /api/tasks/priority を取得する usePriorityTasks フックを追加
- PriorityTasksPanel コンポーネントを実装（期限バッジ、進捗バー、件数表示）
- TaskList を flex 2カラム化（左: 一覧 / 右: 優先タスク）
- Tailwind の読み込み順とテンプレCSSを整理（index.css 上部に @tailwind、body 初期flex削除）
