### PR TITLE
fix: remove unused catch variable to resolve ESLint warning

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,9 +1,95 @@
-const Header = () => {
-    return (
-        <header className="bg-blue-600 text-white p-4">
-            <h1 className="text-lg font-bold">現場タスク管理アプリ</h1>
-        </header>
-    )
-}
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { signOut } from "../lib/apiClient";
+import { devSignIn } from "../lib/devSignIn";
+import { Link } from "react-router-dom";
 
-export default Header
+type Tokens = { uid: string };
+const readTokens = (): Tokens | null => {
+  try {
+    const raw = localStorage.getItem("authTokens");
+    if (!raw) return null;
+    const t = JSON.parse(raw);
+    return t?.uid ? { uid: String(t.uid) } : null;
+  } catch {
+    return null;
+  }
+};
+
+const Header = () => {
+  const [user, setUser] = useState<Tokens | null>(() => readTokens());
+  const nav = useNavigate();
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    const onLogout = () => setUser(null);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "authTokens") setUser(readTokens());
+    };
+    window.addEventListener("auth:logout", onLogout);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("auth:logout", onLogout);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  const handleLogout = () => {
+    signOut();
+    qc.clear();
+    nav("/signin");
+  };
+
+  const handleDevLogin = async () => {
+    await devSignIn();
+    setUser(readTokens());
+    qc.invalidateQueries({ queryKey: ["priorityTasks"] });
+    qc.invalidateQueries({ queryKey: ["tasks"] });
+    nav("/tasks");
+  };
+
+  return (
+    <header className="bg-blue-600 text-white p-4">
+      <div className="max-w-6xl mx-auto p-4 flex items-center justify-between">
+        <Link to="/" className="text-lg font-bold">
+          現場タスク管理アプリ
+        </Link>
+
+        <div className="flex items-center gap-3 text-sm">
+          {user ? (
+            <>
+              <span className="opacity-90">uid: {user.uid}</span>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="px-3 py-1 rounded bg-white/10 hover:bg-white/20"
+              >
+                ログアウト
+              </button>
+            </>
+          ) : (
+            <>
+              <Link
+                to="/signin"
+                className="px-3 py-1 rounded bg-white/10 hover:bg-white/20"
+              >
+                ログイン
+              </Link>
+              <button
+                type="button"
+                onClick={handleDevLogin}
+                className="px-3 py-1 rounded bg-white/10 hover:bg-white/20"
+                title="開発用: dev@example.com / password"
+              >
+                開発ログイン
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -1,0 +1,76 @@
+// src/features/auth/AuthProvider.tsx
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { signIn as apiSignIn, signOut as apiSignOut } from "../../lib/apiClient";
+// （任意）サインアウト時にキャッシュを消したいなら↓を使う
+// import { useQueryClient } from "@tanstack/react-query";
+
+type AuthContextValue = {
+    authed: boolean;
+    uid: string | null;
+    signIn: (email: string, password: string) => Promise<void>;
+    signOut: () => void;
+};
+
+export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function readUidFromTokens(): string | null {
+  try {
+    const raw = localStorage.getItem("authTokens");
+    if (!raw) return null;
+    const obj = JSON.parse(raw) as { uid?: string };
+    return typeof obj.uid === "string" ? obj.uid : null;
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [authed, setAuthed] = useState(false);
+  const [uid, setUid] = useState<string | null>(null);
+  // const qc = useQueryClient(); // ← 使うならコメントアウト解除
+
+  // 初期化：ページ再読み込み後もログイン状態を復元
+  useEffect(() => {
+    const u = readUidFromTokens();
+    if (u) {
+      setAuthed(true);
+      setUid(u);
+    }
+    // apiClient 側で 401 を受け取ったら "auth:logout" を投げる実装なら、ここで購読
+    const onLogout = () => {
+      setAuthed(false);
+      setUid(null);
+      // qc.clear(); // ← 使いたければ
+    };
+    window.addEventListener("auth:logout", onLogout);
+    return () => window.removeEventListener("auth:logout", onLogout);
+  }, []);
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    await apiSignIn(email, password); // interceptor がトークン保存
+    const u = readUidFromTokens();
+    setAuthed(true);
+    setUid(u);
+  }, []);
+
+  const signOut = useCallback(() => {
+    apiSignOut();      // トークン破棄（apiClient.signOut は clearTokens を呼ぶ想定）
+    setAuthed(false);
+    setUid(null);
+    // qc.clear();     // ← 必要なら
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ authed, uid, signIn, signOut }),
+    [authed, uid, signIn, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+// 別ファイルに出してもOK
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/frontend/src/features/auth/RequireAuth.tsx
+++ b/frontend/src/features/auth/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "./AuthProvider";
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+    const { authed } = useAuth();
+    const loc = useLocation();
+    if (!authed) {
+        return <Navigate to="/signin" replace state={{ from: loc }} />;
+    }
+    return <>{children}</>;
+}

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -1,0 +1,66 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "../features/auth/AuthProvider";
+import { useState } from "react";
+
+type FromState = { from?: { pathname: string } } | null;
+
+export default function SignInPage() {
+  const { signIn } = useAuth();
+  const nav = useNavigate();
+  const loc = useLocation();
+  const redirectTo = (loc.state as FromState)?.from?.pathname ?? "/tasks";
+
+  const [email, setEmail] = useState("dev@example.com");
+  const [password, setPassword] = useState("password");
+  const [pending, setPending] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  return (
+    <div className="max-w-sm mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">サインイン</h1>
+      <form
+        className="space-y-3"
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setErr(null);
+          setPending(true);
+          try {
+            await signIn(email, password);
+            nav(redirectTo, { replace: true });
+          } catch {
+            setErr("ログインに失敗しました");
+          } finally {
+            setPending(false);
+          }
+        }}
+      >
+        <label className="block">
+          <span className="text-sm">メール</span>
+          <input
+            className="mt-1 w-full border rounded p-2"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">パスワード</span>
+          <input
+            className="mt-1 w-full border rounded p-2"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        {err && <p className="text-sm text-red-600">{err}</p>}
+        <button
+          type="submit"
+          disabled={pending}
+          className="w-full bg-gray-900 text-white rounded py-2 disabled:opacity-60"
+        >
+          {pending ? "送信中..." : "ログイン"}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
- ヘッダーにログイン・ログアウトボタンを追加
- 認証状態に応じて表示を切り替え
- AuthContextを導入し、サインイン/サインアウト処理を管理
- ESLintの `no-unused-vars` 警告を解消

## 変更内容
- AuthProviderコンポーネントを作成
- ヘッダーにログイン・ログアウトボタンを追加
- サインインページの不要なcatch変数 `_e` を削除
- APIクライアントを使ったサインイン/サインアウト処理を実装
