### PR TITLE
feat(auth): redirect authenticated users away from /login

### DIFF
--- a/frontend/src/components/RedirectIfAuthed.tsx
+++ b/frontend/src/components/RedirectIfAuthed.tsx
@@ -1,0 +1,16 @@
+import type React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../providers/useAuth";
+
+type RouteState = { from?: { pathname?: string } };
+
+export default function RedirectIfAuthed({ children }: { children: React.ReactNode }) {
+  const { authed } = useAuth();
+  const loc = useLocation();
+  if (authed) {
+    const state = (loc.state ?? null) as RouteState | null;
+    const to = state?.from?.pathname ?? "/tasks";
+    return <Navigate to={to} replace />;
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -5,12 +5,13 @@ import TaskList from "../pages/TaskList";
 import Summary from "../pages/Summary";
 import Layout from "../components/Layout";
 import RequireAuth from "../components/RequireAuth";
+import RedirectIfAuthed from "../components/RedirectIfAuthed";
 
 export const AppRouter = () => (
   <BrowserRouter>
     <Routes>
       {/* 非ログインOK */}
-      <Route path="/login" element={<Login />} />
+      <Route path="/login" element={<RedirectIfAuthed><Login /></RedirectIfAuthed>} />
       <Route path="/signin" element={<Navigate to="/login" replace />} />
 
       {/* 認証必須 */}


### PR DESCRIPTION
概要

ログイン済みユーザーが /login にアクセスした際、自動で /tasks または直前のページへリダイレクトする仕組みを追加


変更点

新規コンポーネント追加
src/components/RedirectIfAuthed.tsx
認証済みの場合、useLocation().state.from?.pathname へリダイレクト
デフォルトは /tasks
ルーター適用
src/router/AppRouter.tsx
/login ルートを RedirectIfAuthed でラップし、ログイン済みユーザーのアクセスを制御