### PR TITLE
fix(auth): clear session-expired flag once; remove unused setter

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "../providers/useAuth";
 
@@ -35,9 +35,30 @@ export default function Login() {
     }
   };
 
+  const [expired] = useState<boolean>(() => {
+    try {
+      return sessionStorage.getItem("auth:expired") === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  // 表示後にフラグは一度だけ出す
+  useEffect(() => {
+    if (expired) {
+        try { sessionStorage.removeItem("auth:expired"); } catch {/* ignore */}
+    }
+  }, [expired]);
+  
   return (
     <div className="mx-auto max-w-sm p-6">
       <h1 className="text-2xl font-bold mb-4">ログイン</h1>
+      {expired && (
+        <p className="mb-3 text-sm text-orange-700 bg-orange-50 border border-orange-200 rounded p-2">
+          セッションが切れました。再度ログインしてください
+        </p>
+      )}
+
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm mb-1">メールアドレス</label>


### PR DESCRIPTION
概要

セッション切れ（401）でログアウトされた際、ログイン画面に「セッションが切れました。再度ログインしてください。」という通知を表示するようにした



変更点

Loginページに通知フラグ追加
useState で初期値として sessionStorage.getItem("auth:expired") を確認
値が "1" なら通知を表示し、直後にフラグを削除
通知UI
ログイン画面の冒頭にオレンジ色のインフォメッセージを表示
セッション切れ理由をユーザーに分かりやすく説明