### PR TITLE
feat(auth): return-to previous page after 401

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "../providers/useAuth";
 
 type RouteState = { from?: { pathname?: string } };
+const isSafePath = (p: string | null): p is string =>
+    !!p && p.startsWith("/") && !p.startsWith("//");
 
 function getErrorMessage(e: unknown): string {
   if (e instanceof Error) return e.message;
@@ -14,7 +16,14 @@ export default function Login() {
   const loc = useLocation();
   const { signIn } = useAuth();
   const state = (loc.state ?? null) as RouteState | null;
-  const from = state?.from?.pathname ?? "/tasks";
+  const savedFrom = (() => {
+    try {
+        const v = sessionStorage.getItem("auth:from");
+        if (v) sessionStorage.removeItem("auth:from");
+        return v ?? null;
+    } catch { return null; }
+  })();
+  const from = isSafePath(savedFrom) ? savedFrom : (state?.from?.pathname ?? "/tasks");
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");


### PR DESCRIPTION
概要

401（セッション切れ）や明示ログアウト後、直前にいたページへ復帰できるようにした

復帰先は sessionStorage.auth:from に保存し、ログイン成功時に一度だけ消費


 変更点
 401 時に元ページを保存して /login へ
src/providers/AuthContext.tsx
レスポンスインターセプターで 401 検知時に
auth:from に 相対パスのみ保存（/path?query#hash）
auth:expired = "1" をセット（既存のセッション切れ通知に利用）
トークン破棄 → /login へ replace 遷移