### PR TITLE
chore(auth): clear React Query cache on logout via global auth:logout…

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,11 @@ const queryClient = new QueryClient({
   },
 });
 
+// ログアウトイベントでキャッシュ全消去
+window.addEventListener("auth:logout", () => {
+  queryClient.clear();
+});
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/providers/AuthContext.tsx
+++ b/frontend/src/providers/AuthContext.tsx
@@ -80,6 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             } catch { /* ignore */}
         }
         clearTokens();
+        try { window.dispatchEvent(new Event("auth:logout")); } catch { /* ignore */ }
         if (!silent) window.location.replace("/login");
     }
   }, [clearTokens]);
@@ -99,6 +100,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 sessionStorage.setItem("auth:expired", "1");
             } catch {/* ignore */}
             clearTokens();
+            try { window.dispatchEvent(new Event("auth:logout")); } catch {/* ignore */}
             window.location.replace("/login");
         }
         return Promise.reject(error);


### PR DESCRIPTION
概要

ログアウト（明示/401 どちらも）時に、React Query のキャッシュを全削除する仕組みを追加

不要データが残ったまま別ユーザーに引き継がれるのを防止



 変更点
 グローバル購読
src/main.tsx
QueryClient 初期化後に window.addEventListener("auth:logout", …) を追加
auth:logout イベントを受け取ると queryClient.clear() を実行し、全キャッシュをクリア

 イベント発火
src/providers/AuthContext.tsx
401ハンドラとsignOut() 両方で window.dispatchEvent(new Event("auth:logout")) を呼び出す
ログアウト処理と同時にキャッシュも破棄される


 動作確認
 ログイン後に /tasks を開いてキャッシュが溜まる
 signOut() 実行時 → キャッシュが全消去される
 セッション切れ（401）で強制ログアウト時もキャッシュが全消去される
 別ユーザーでログインし直した際、前ユーザーのタスク等が混ざらない