### PR TITLE
test(e2e): add Playwright auth smoke tests; a11y label/id; npm scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "check": "npm run lint && npm run typecheck"
+    "check": "npm run lint && npm run typecheck",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.54.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests',
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -70,20 +70,26 @@ export default function Login() {
 
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm mb-1">メールアドレス</label>
-          <input
+        <label htmlFor="login-email" className="block text-sm mb-1">メールアドレス</label>
+        <input
+            id="login-email"
+            name="email"
+            data-testid="login-email"
             className="w-full border rounded p-2"
             type="email"
             autoComplete="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-          />
+            />
         </div>
 
         <div>
-          <label className="block text-sm mb-1">パスワード</label>
+          <label htmlFor="login-password" className="block text-sm mb-1">パスワード</label>
           <input
+            id="login-password"
+            name="password"
+            data-testid="login-password"
             className="w-full border rounded p-2"
             type="password"
             autoComplete="current-password"
@@ -91,7 +97,7 @@ export default function Login() {
             onChange={(e) => setPassword(e.target.value)}
             required
             minLength={6}
-          />
+            />
         </div>
 
         {error && <p className="text-red-600 text-sm">{error}</p>}

--- a/frontend/tests/auth.spec.ts
+++ b/frontend/tests/auth.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+const USER = { email: 'test@example.com', password: 'password' };
+
+test('未ログインで /tasks は /login へ', async ({ page }) => {
+  await page.goto('/tasks');
+  await expect(page).toHaveURL(/\/login$/);
+});
+
+test('ログイン成功で /tasks へ', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('メールアドレス').fill(USER.email);
+  await page.getByLabel('パスワード').fill(USER.password);
+  await page.getByRole('button', { name: 'ログイン' }).click();
+  await expect(page).toHaveURL(/\/tasks$/);
+  await expect(page.getByText('タスク一覧ページ')).toBeVisible();
+});
+
+test('401で /login へ（セッション切れ表示）', async ({ page }) => {
+    // まずログイン
+    await page.goto('/login');
+    await page.getByLabel('メールアドレス').fill(USER.email);
+    await page.getByLabel('パスワード').fill(USER.password);
+    await page.getByRole('button', { name: 'ログイン' }).click();
+    await expect(page).toHaveURL(/\/tasks$/);
+  
+  // トークンを消して未ログイン状態にし、セッション切れフラグを明示的に立てる
+  await page.evaluate(() => {
+    localStorage.removeItem('access-token');
+    localStorage.removeItem('client');
+    localStorage.removeItem('uid');
+    sessionStorage.setItem('auth:expired', '1'); // ← ログイン画面で一度だけ表示されるバナー用
+  });
+  
+    // 保護ページを踏ませて /login へ誘導（RequireAuth でリダイレクト）
+  await page.goto('/tasks');
+  await expect(page).toHaveURL(/\/login$/);
+  
+    // セッション切れのバナーが表示されること
+  await expect(page.getByText(/セッションが切れました/)).toBeVisible();
+  });


### PR DESCRIPTION
## 目的
- 認証フローの最低限の品質を E2E で自動検証し、リグレッションを早期検知する。
  - 未ログインガード
  - 通常ログイン遷移
  - セッション切れ時の通知表示

## 変更点
- Playwright 設定を追加：`playwright.config.ts`
  - `webServer: npm run dev` / `baseURL: http://localhost:5173`
- テストを追加：`tests/auth.spec.ts`（3本）
  1. 未ログイン `/tasks` → `/login`
  2. ログイン成功 → `/tasks`
  3. セッション切れ表示（トークン削除＋フラグで再現）→ `/login` で通知
- npm scripts 追加（`package.json`）
  - `"test:e2e": "playwright test"`
  - `"test:e2e:ui": "playwright test --ui"`
- アクセシビリティ & テスト安定化
  - `Login.tsx` のラベルを `htmlFor`/`id` で input と関連付け（`getByLabel` が安定ヒット）
