### PR TITLE
feat(subtasks): 親タスク直下のサブタスク作成・表示・折りたたみ（2段まで）

### DIFF
--- a/frontend/src/features/tasks/nest.ts
+++ b/frontend/src/features/tasks/nest.ts
@@ -1,0 +1,19 @@
+import type { Task } from "../../types/task";
+
+export function nestTasks(flat: Task[]): Task[] {
+  const byId = new Map<number, Task & { children: Task[]; depth: number }>();
+  flat.forEach(t => byId.set(t.id, { ...t, children: [], depth: 1 }));
+
+  const roots: Task[] = [];
+  byId.forEach(t => {
+    if (t.parent_id && byId.has(t.parent_id)) {
+      const p = byId.get(t.parent_id)!;
+      t.depth = p.depth + 1;
+      p.children.push(t);
+    } else {
+      t.depth = 1;
+      roots.push(t);
+    }
+  });
+  return roots;
+}

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,15 +1,19 @@
 // src/pages/TaskList.tsx
-  import { useState } from "react";
+  import { useMemo, useState } from "react";
   import TaskItem from "../components/TaskItem";
   import type { Task } from "../types/task";
   import PriorityTasksPanel from "../features/priority/PriorityTasksPanel";
   import { useTasks } from "../features/tasks/useTasks";
   import { useAuth } from "../providers/useAuth";
   import NewTaskButton from "../components/NewTaskButton";
+  import { usePriorityTasks } from "../features/priority/usePriorityTasks";
+  import { nestTasks } from "../features/tasks/nest";
 
 export default function TaskList() {
   const { authed } = useAuth();
-  const { data: tasks = [] } = useTasks(authed);
+  const { data: priority } = usePriorityTasks(authed);
+  const { data: tasksFlat = [] } = useTasks(authed);
+  const tasks = useMemo(() => nestTasks(tasksFlat), [tasksFlat]); // ★ ツリー化
 
   return (
     <div className="max-w-6xl mx-auto p-4">

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -7,5 +7,5 @@ export type Task = {
     parent_id: number | null;
     depth?: number;
     description?: string | null;
-    children?: Task[]; // ここoptional
+    children?: Task[];
   };


### PR DESCRIPTION
## 目的
親子構造を最小スコープで導入し、親の直下にサブタスクを追加・表示できるようにする。

## 変更
- Task に parent_id を追加
- nestTasks でフラット配列をツリー化（React Query キャッシュはフラット維持）
- useCreateTask: { title, deadline, parentId } を受けて /tasks POST（strong_params）
- TaskItem:
  - ＋サブタスク（親の直下のみ）
  - 子の折りたたみトグル
  - 子がある親の削除をブロック（サーバ挙動が未確定のため安全策）

## 動作確認
- 親→＋サブタスク→作成→即表示
- 親の折りたたみ/展開が動作
- 子がある親は削除不可警告

## 後続
- 子タスクの編集/削除
- E2E: サブタスクの作成/折りたたみ/ガード
