### PR TITLE
Feat/tasks sort and filter

### DIFF
--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -1,71 +1,131 @@
 class Task < ApplicationRecord
-  # アソシエーション(関連付け)
-  belongs_to :user 
+  # アソシエーション
+  belongs_to :user
+  belongs_to :parent, class_name: "Task", optional: true
+  has_many   :children, class_name: "Task", foreign_key: "parent_id", dependent: :destroy
 
-  # 自己結合アソシエーション
-  belongs_to :parent, class_name: "Task", optional:true
-  has_many :children, class_name: "Task", foreign_key: "parent_id", dependent: :destroy
-
-  # 進捗ステータス(0:未着手, 1:進行中, 2:完了)
+  # ステータス
   enum :status, { not_started: 0, in_progress: 1, completed: 2 }
 
   # バリデーション
   validates :title, presence: true
   validates :status, presence: true
-  # 親（= parent_id が nil）のときだけ site 必須
-  validates :site, presence: true, if: -> { parent_id.nil? }
-  validate :depth_limit
+  validates :site,   presence: true, if: -> { parent_id.nil? } # 親のみsite必須
+  validate  :depth_limit
 
-  # 新規作成時のみ、保存前に自動でdepthを計算
+  # depthは作成時に自動計算
   before_validation :set_depth, on: :create
 
   # 子のprogress変更 / 親付け替え / 削除 を拾う
   after_save    :update_parent_progress_if_needed
   after_destroy :update_parent_progress
 
+  # ---------- ロールアップ（確定後に実行） ----------
+  after_commit :recalc_new_parent,        on: [:create, :update]
+  after_commit :recalc_old_parent,        on: :update, if: -> { saved_change_to_parent_id? }
+  after_commit :recalc_parent_on_destroy, on: :destroy
+
+  def recalc_new_parent
+    parent&.recalc_from_children!
+  end
+
+  def recalc_old_parent
+    old_id = parent_id_before_last_save
+    Task.find_by(id: old_id)&.recalc_from_children! if old_id.present?
+  end
+
+  def recalc_parent_on_destroy
+    Task.find_by(id: parent_id)&.recalc_from_children!
+  end
+
+  # 親自身を子のprogress平均で更新し、祖先へ伝播
+  def recalc_from_children!
+    if children.exists?
+      avg = children.average(:progress)
+      update_columns(progress: (avg ? avg.to_f.round : 0))
+    else
+      update_columns(progress: 0)
+    end
+    parent&.recalc_from_children!
+  end
+  # -----------------------------------------------
+
+  # 優先タスク（未完了/期限→進捗）
   scope :priority_order, -> {
     where.not(status: :completed)
-      .order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END"), :deadline, :progress)
+      .order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END ASC"))
+      .order(:deadline, :progress)
       .limit(5)
   }
 
-   # ---------- ロールアップ（確定後に実行） ----------
-   after_commit :recalc_new_parent, on: [:create, :update]
-   after_commit :recalc_old_parent, on: :update, if: -> { saved_change_to_parent_id? }
-   after_commit :recalc_parent_on_destroy, on: :destroy
- 
-   def recalc_new_parent
-     parent&.recalc_from_children!
-   end
- 
-   def recalc_old_parent
-     old_id = parent_id_before_last_save # Rails 7+ でOK（8も可）
-     Task.find_by(id: old_id)&.recalc_from_children! if old_id.present?
-   end
- 
-   def recalc_parent_on_destroy
-     Task.find_by(id: parent_id)&.recalc_from_children!
-   end
- 
-   # 親自身を子のprogress平均で更新し、祖先へ伝播
-   def recalc_from_children!
-     if children.exists?
-       avg = children.average(:progress)
-       update_columns(progress: (avg ? avg.to_f.round : 0))
-     else
-       update_columns(progress: 0)
-     end
-     parent&.recalc_from_children!
-   end
-   # -----------------------------------------------
+  # ===== 絞り込み・並び替え =====
+  scope :for_user, ->(user) { where(user_id: user.id) }
 
-    # 階層ツリーをJSON化（子を再帰）
-    def as_tree
-      {
-        id:, title:, status:, progress:, depth:, deadline:, description:, site:,
-        children: children.map(&:as_tree)
-      }
+  scope :by_site, ->(site) {
+    site.present? ? where(site: site) : all
+  }
+
+  # "not_started"/"in_progress"/"completed" または "0/1/2" を受け付ける
+  scope :by_status, ->(statuses_param) {
+    vals = Array(statuses_param).map(&:to_s)
+    next all if vals.blank?
+
+    normalized = vals.map { |s|
+      if statuses.key?(s) # enum名
+        s
+      elsif (i = Integer(s, exception: false)).is_a?(Integer) && statuses.invert.key?(i) # 数値
+        statuses.invert[i]
+      end
+    }.compact.uniq
+    normalized.present? ? where(status: normalized) : none
+  }
+
+  scope :by_progress_min, ->(min) {
+    min.present? ? where("COALESCE(progress,0) >= ?", min.to_i) : all
+  }
+
+  scope :by_progress_max, ->(max) {
+    max.present? ? where("COALESCE(progress,0) <= ?", max.to_i) : all
+  }
+
+  # 親だけ表示（親=site必須、子はsite任意）
+  scope :parents_only, ->(flag) {
+    flag.to_s == "1" ? where(parent_id: nil) : all
+  }
+
+  ORDERABLE_COLUMNS = %w[deadline progress created_at].freeze
+
+  # エントリポイント
+  def self.filter_sort(p, user:)
+    rel = for_user(user)
+            .parents_only(p[:parents_only])
+            .by_site(p[:site])
+            .by_status(p[:status])
+            .by_progress_min(p[:progress_min])
+            .by_progress_max(p[:progress_max])
+
+    order_by = ORDERABLE_COLUMNS.include?(p[:order_by].to_s) ? p[:order_by].to_s : "deadline"
+    dir      = %w[asc desc].include?(p[:dir].to_s.downcase) ? p[:dir].to_s.upcase : "ASC"
+
+    case order_by
+    when "deadline"
+      # NULLS LAST 相当（SQLiteでも効く）
+      rel.order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END ASC"))
+         .order("deadline #{dir}")
+    when "progress"
+      rel.order(Arel.sql("COALESCE(progress,0) #{dir}"))
+    else
+      rel.order("created_at #{dir}")
     end
+  end
+
+  # 階層ツリーをJSON化（子を再帰）
+  def as_tree
+    {
+      id:, title:, status:, progress:, depth:, deadline:, description:, site:,
+      children: children.map(&:as_tree)
+    }
+  end
 
   # 親のprogressを「子のprogressの平均」で更新（再帰）
   def update_parent_progress
@@ -73,7 +133,7 @@ class Task < ApplicationRecord
 
     if parent.children.exists?
       avg = parent.children.average(:progress).to_f
-      parent.update_column(:progress, avg.round)  # 整数で良ければ .round(0)
+      parent.update_column(:progress, avg.round)
     else
       parent.update_column(:progress, 0)
     end
@@ -93,8 +153,7 @@ class Task < ApplicationRecord
     end
   end
 
-  # progress/parent_id/status の変更で発火
-  #    親付け替え時は旧親も再計算
+  # progress/parent_id/status の変更で発火（親付け替え時は旧親も再計算）
   def update_parent_progress_if_needed
     if saved_change_to_progress? || saved_change_to_parent_id? || saved_change_to_status?
       if saved_change_to_parent_id?
@@ -103,63 +162,5 @@ class Task < ApplicationRecord
       end
       parent&.update_parent_progress
     end
-  end
-end
-
-  # ===== 絞り込み・並び替え =====
-  scope :for_user, ->(user) { where(user_id: user.id) } # 認証前提なら
-
-  scope :by_site, ->(site) {
-    site.present? ? where(site: site) : all
-  }
-
-  # status は "not_started"/"in_progress"/"completed" か、0/1/2 のどちらでも受け付ける
-  scope :by_status, ->(statuses) {
-    return all if statuses.blank?
-    names = Array(statuses).map(&:to_s)
-    normalized = names.map { |s|
-      if statuses().key?(s)           # enum名
-        s
-      elsif Integer(s, exception: false).is_a?(Integer) && statuses().invert.key?(s.to_i) # 数値
-        statuses().invert[s.to_i]
-      end
-    }.compact.uniq
-    normalized.present? ? where(status: normalized) : none
-  }
-
-  scope :by_progress_min, ->(min) {
-    min.present? ? where('progress >= ?', min.to_i) : all
-  }
-
-  scope :by_progress_max, ->(max) {
-    max.present? ? where('progress <= ?', max.to_i) : all
-  }
-
-  # 親だけ表示（親=site必須、子はsite任意なので親ビュー用に便利）
-  scope :root_only, ->(flag) {
-    flag.to_s == '1' ? where(parent_id: nil) : all
-  }
-
-  # 並び替えはホワイトリストで防御
-  ORDERABLE_COLUMNS = {
-    "deadline"   => :deadline,
-    "progress"   => :progress,
-    "created_at" => :created_at
-  }.freeze
-
-  scope :order_by_param, ->(order_by, dir = 'asc') {
-    column = ORDERABLE_COLUMNS[order_by.to_s] || :deadline
-    direction = %w[asc desc].include?(dir.to_s) ? dir : 'asc'
-    order(column => direction)
-  }
-
-  def self.filter_sort(p, user:)
-    for_user(user)
-      .root_only(p[:parents_only])
-      .by_site(p[:site])
-      .by_status(p[:status])
-      .by_progress_min(p[:progress_min])
-      .by_progress_max(p[:progress_max])
-      .order_by_param(p[:order_by], p[:dir])
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,9 +1,12 @@
 Rails.application.routes.draw do
   namespace :api do
     mount_devise_token_auth_for 'User', at: 'auth'
-    
+
     resources :tasks do
-      collection { get :priority }
+      collection do
+        get :priority
+        get :sites
+      end
     end
   end
 end

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -26,6 +26,7 @@ const Header = () => {
                 type="button"
                 onClick={handleLogout}
                 className="px-3 py-1 rounded bg-white/10 hover:bg-white/20"
+                data-testid="header-logout"
               >
                 ログアウト
               </button>

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -10,7 +10,6 @@ type Props = {
     onToggleComplete: (id: number) => void; // 親から渡してもらう
 };
 
-
 const TaskCard = ({ task, onToggleComplete }: Props) => {
     const isCompleted = task.status === "completed";
 
@@ -22,7 +21,7 @@ const TaskCard = ({ task, onToggleComplete }: Props) => {
                 {/* チェックボックス */}
                 <label className="inline-flex items-center gap-1 text-sm">
                     <input
-                        type="checkebox"
+                        type="checkbox"
                         checked={isCompleted}
                         onChange={() => onToggleComplete(task.id)}
                         className="h-4 w-4 text-emerald-600 border-gray-300 rounded focus:ring-emerald-500"

--- a/frontend/src/components/TaskItem.tsx
+++ b/frontend/src/components/TaskItem.tsx
@@ -89,6 +89,7 @@ export default function TaskItem({ task }: TaskItemProps) {
               <h2 className="text-lg font-semibold truncate">{task.title}</h2>
               <p className="text-sm text-gray-600 flex items-center gap-2">
                 期限: {task.deadline ?? "未設定"} ・ ステータス: {task.status}
+                {task.site ? <> ・ site: {task.site}</> : null}
                 <label className="inline-flex items-center gap-1 text-xs ml-2">
                   <input
                     type="checkbox"

--- a/frontend/src/features/tasks/TaskFilterBar.tsx
+++ b/frontend/src/features/tasks/TaskFilterBar.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+const STATUSES = ["not_started", "in_progress", "completed"] as const;
+
+export function TaskFilterBar() {
+  const [sp, setSp] = useSearchParams();
+
+  const filters = useMemo(
+    () => ({
+      site: sp.get("site") || "",
+      status: sp.getAll("status"),
+      progress_min: Number(sp.get("progress_min") ?? "0"),
+      progress_max: Number(sp.get("progress_max") ?? "100"),
+      order_by: (sp.get("order_by") ?? "deadline") as
+        | "deadline"
+        | "progress"
+        | "created_at",
+      dir: (sp.get("dir") ?? "asc") as "asc" | "desc",
+    }),
+    [sp]
+  );
+
+  const patch = (
+    obj: Record<string, string | string[] | number | undefined>
+  ) => {
+    const curr = Object.fromEntries(sp.entries());
+    const next: Record<string, string> = { ...curr };
+
+    Object.entries(obj).forEach(([k, v]) => {
+      if (Array.isArray(v)) {
+        // 一旦削除して複数値を入れ直す
+        delete next[k];
+      } else if (v === "" || v === undefined) {
+        delete next[k];
+      } else {
+        next[k] = String(v);
+      }
+    });
+
+    const nextSp = new URLSearchParams(next);
+    Object.entries(obj).forEach(([k, v]) => {
+      if (Array.isArray(v)) v.forEach((val) => nextSp.append(k, val));
+    });
+    setSp(nextSp, { replace: false });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 p-3 border rounded-xl">
+      <input
+        className="border rounded px-2 py-1"
+        placeholder="現場名(site)"
+        value={filters.site}
+        onChange={(e) => patch({ site: e.target.value })}
+      />
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={filters.parents_only === "1"}
+          onChange={(e) =>
+            patch({ parents_only: e.target.checked ? "1" : undefined })
+          }
+        />
+        親タスクのみ
+      </label>
+
+      <label className="flex items-center gap-2">
+        進捗 {filters.progress_min}%–{filters.progress_max}%
+        <input
+          type="number"
+          min={0}
+          max={100}
+          value={filters.progress_min}
+          onChange={(e) => patch({ progress_min: Number(e.target.value) })}
+          className="w-16 border rounded px-1 py-0.5"
+        />
+        <input
+          type="number"
+          min={0}
+          max={100}
+          value={filters.progress_max}
+          onChange={(e) => patch({ progress_max: Number(e.target.value) })}
+          className="w-16 border rounded px-1 py-0.5"
+        />
+      </label>
+
+      <div className="flex items-center gap-2">
+        {STATUSES.map((s) => {
+          const on = filters.status.includes(s);
+          return (
+            <button
+              key={s}
+              className={`px-2 py-1 rounded border ${on ? "font-bold" : ""}`}
+              onClick={() => {
+                const set = new Set(filters.status);
+                on ? set.delete(s) : set.add(s);
+                patch({ status: Array.from(set) });
+              }}
+            >
+              {s}
+            </button>
+          );
+        })}
+      </div>
+
+      <select
+        value={`${filters.order_by}:${filters.dir}`}
+        onChange={(e) => {
+          const [order_by, dir] = e.target.value.split(":");
+          patch({ order_by, dir });
+        }}
+        className="border rounded px-2 py-1"
+      >
+        <option value="deadline:asc">期限 ↑</option>
+        <option value="deadline:desc">期限 ↓</option>
+        <option value="progress:asc">進捗 ↑</option>
+        <option value="progress:desc">進捗 ↓</option>
+        <option value="created_at:desc">新着 ↓</option>
+        <option value="created_at:asc">新着 ↑</option>
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/features/tasks/TaskFilterBar.tsx
+++ b/frontend/src/features/tasks/TaskFilterBar.tsx
@@ -1,10 +1,17 @@
 import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import { useSites } from "./useSites";
+import { readSiteHistory } from "../../lib/siteHistory";
 
 const STATUSES = ["not_started", "in_progress", "completed"] as const;
 
 export function TaskFilterBar() {
   const [sp, setSp] = useSearchParams();
+  const { data: serverSites = [] } = useSites(true);
+  const localSites = readSiteHistory();
+  const siteOptions = Array.from(
+    new Set([...localSites, ...serverSites])
+  ).slice(0, 50);
 
   const filters = useMemo(
     () => ({
@@ -50,9 +57,15 @@ export function TaskFilterBar() {
       <input
         className="border rounded px-2 py-1"
         placeholder="現場名(site)"
+        list="site-options"
         value={filters.site}
         onChange={(e) => patch({ site: e.target.value })}
       />
+      <datalist id="site-options">
+        {siteOptions.map((s) => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
 
       <label className="flex items-center gap-2">
         <input

--- a/frontend/src/features/tasks/useSites.ts
+++ b/frontend/src/features/tasks/useSites.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../lib/apiClient";
+
+export function useSites(enabled = true) {
+  return useQuery<string[], Error>({
+    queryKey: ["sites"],
+    queryFn: async () => {
+      const { data } = await api.get<string[]>("/tasks/sites");
+      return data;
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/features/tasks/useTasks.ts
+++ b/frontend/src/features/tasks/useTasks.ts
@@ -1,28 +1,48 @@
+// src/features/tasks/useTasks.ts
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../lib/apiClient";
 import type { Task } from "../../types/task";
 
-// APIの揺れを型で吸収
-type TasksResponse = Task[] | { tasks: Task[] };
+// ---- 新規: フィルタ型 ----
+export type TaskFilters = {
+  site?: string;
+  status?: string[]; // ["not_started","in_progress","completed"]
+  progress_min?: number;
+  progress_max?: number;
+  order_by?: "deadline" | "progress" | "created_at";
+  dir?: "asc" | "desc";
+  parents_only?: "1" | "0"; // 親のみ表示
+};
 
+// APIの揺れを型で吸収（サーバ側は配列返却でOKだが念のため）
+type TasksResponse = Task[] | { tasks: Task[] };
 function normalizeTasks(data: TasksResponse): Task[] {
   return Array.isArray(data) ? data : data.tasks;
 }
 
-async function fetchTasks(): Promise<Task[]> {
-  const { data } = await api.get<TasksResponse>("/tasks");
+// ---- 新規: フィルタ対応の取得関数 ----
+async function fetchTasks(filters?: TaskFilters): Promise<Task[]> {
+  // NOTE: APIは /api/tasks を叩く
+  const { data } = await api.get<TasksResponse>("/tasks", { params: filters });
   return normalizeTasks(data);
 }
 
-export function useTasks(enabled: boolean) {
+// ---- 新規: フィルタ対応フック ----
+export function useFilteredTasks(filters: TaskFilters, enabled = true) {
+  // filters を queryKey に入れることで操作に応じて自動リフェッチ
   return useQuery<Task[], Error>({
-    queryKey: ["tasks"],
-    queryFn: fetchTasks,
+    queryKey: ["tasks", filters],
+    queryFn: () => fetchTasks(filters),
     enabled,
     staleTime: 30_000,
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
-    refetchOnReconnect: "always", 
+    refetchOnReconnect: "always",
     retry: false,
   });
+}
+
+// ---- 既存互換: 引数が boolean のままでも動くように薄ラッパーを残す ----
+export function useTasks(enabled: boolean) {
+  return useFilteredTasks({}, enabled);
 }

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delay = 300): T {
+  const [v, setV] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setV(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return v;
+}

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -9,12 +9,13 @@ import { usePriorityTasks } from "../features/priority/usePriorityTasks";
 import { nestTasks } from "../features/tasks/nest";
 import NewParentTaskForm from "../components/NewParentTaskForm";
 import { TaskFilterBar } from "../features/tasks/TaskFilterBar";
+import { useDebouncedValue } from "../hooks/useDebouncedValue";
 
 export default function TaskList() {
   const { authed } = useAuth();
   usePriorityTasks(authed); // 読み込み副作用だけ必要なら data を使わなくてもOK
   const [sp] = useSearchParams();
-  const filters = {
+  const rawFilters = {
     site: sp.get("site") || undefined,
     status: sp.getAll("status"),
     progress_min: sp.get("progress_min")
@@ -29,6 +30,7 @@ export default function TaskList() {
     dir: (sp.get("dir") as "asc" | "desc") || "asc",
     parents_only: sp.get("parents_only") === "1" ? "1" : undefined,
   };
+  const filters = useDebouncedValue(rawFilters, 300);
   const { data: tasksFlat = [] } = useFilteredTasks(filters, authed);
 
   // フラット配列 → ツリー化

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,17 +1,35 @@
 // src/pages/TaskList.tsx
 import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import TaskItem from "../components/TaskItem";
 import PriorityTasksPanel from "../features/priority/PriorityTasksPanel";
-import { useTasks } from "../features/tasks/useTasks";
+import { useFilteredTasks } from "../features/tasks/useTasks";
 import { useAuth } from "../providers/useAuth";
 import { usePriorityTasks } from "../features/priority/usePriorityTasks";
 import { nestTasks } from "../features/tasks/nest";
 import NewParentTaskForm from "../components/NewParentTaskForm";
+import { TaskFilterBar } from "../features/tasks/TaskFilterBar";
 
 export default function TaskList() {
   const { authed } = useAuth();
-  usePriorityTasks(authed);             // 読み込み副作用だけ必要なら data を使わなくてもOK
-  const { data: tasksFlat = [] } = useTasks(authed);
+  usePriorityTasks(authed); // 読み込み副作用だけ必要なら data を使わなくてもOK
+  const [sp] = useSearchParams();
+  const filters = {
+    site: sp.get("site") || undefined,
+    status: sp.getAll("status"),
+    progress_min: sp.get("progress_min")
+      ? Number(sp.get("progress_min"))
+      : undefined,
+    progress_max: sp.get("progress_max")
+      ? Number(sp.get("progress_max"))
+      : undefined,
+    order_by:
+      (sp.get("order_by") as "deadline" | "progress" | "created_at") ||
+      "deadline",
+    dir: (sp.get("dir") as "asc" | "desc") || "asc",
+    parents_only: sp.get("parents_only") === "1" ? "1" : undefined,
+  };
+  const { data: tasksFlat = [] } = useFilteredTasks(filters, authed);
 
   // フラット配列 → ツリー化
   const tasks = useMemo(() => nestTasks(tasksFlat), [tasksFlat]);
@@ -22,6 +40,7 @@ export default function TaskList() {
         <h1 className="text-2xl font-bold">タスク一覧ページ</h1>
       </div>
 
+      <TaskFilterBar />
       <div className="flex gap-6 items-start">
         <section className="flex-1 space-y-3">
           {/* 親タスク作成フォーム（現場名必須）はここ */}


### PR DESCRIPTION
背景 / 目的

タスク一覧に絞り込みと並び替えを実装して、現場単位や進捗での視認性を上げる。

親タスク作成時の現場名入力補助として、既存site候補をAPIで提供する。

変更点（サマリ）

Model: Task.filter_sort(params, user:) を新規実装

絞り込み: site, status（enum名 or 0/1/2）, progress_min/max, parents_only

並び替え: order_by=deadline|progress|created_at, dir=asc|desc

deadline は NULLS LAST、progress は COALESCE(progress,0) で安定化

API: GET /api/tasks を上記フィルタ＆ソートに対応

安全のためホワイトリストで order_by/dir を検証

strong_params から :depth を除外（モデルが自動算出）

API（新規）: GET /api/tasks/sites

親タスク（parent_id: nil）の site を distinct で返す（空/NULLは除外）

Frontend:

TaskFilterBar をAPI仕様に統一（status=enum名、order_by/dirの値を揃える）

useSites 追加 & datalist でsite入力補助

TaskItem の期限表示を MM/DD(曜) に整形（表示のみ）