### PR TITLE
feat(tasks): 親直下の子タスクを最大4件に制限 + status/progress のデフォルトを付与（P0-1）

### DIFF
--- a/backend/db/migrate/20250823023751_add_defaults_to_tasks.rb
+++ b/backend/db/migrate/20250823023751_add_defaults_to_tasks.rb
@@ -1,0 +1,21 @@
+class AddDefaultsToTasks < ActiveRecord::Migration[8.0]
+  def up
+    execute "UPDATE tasks SET status = 0 WHERE status IS NULL"
+    execute "UPDATE tasks SET progress = 0 WHERE progress IS NULL"
+
+    change_column_default :tasks, :status, 0
+    change_column_null :tasks, :status, false
+
+    change_column_default :tasks, :progress, 0
+    # 任意: progress も NOT NULL にしたいなら次を有効化
+    # change_column_null    :tasks, :progress, false
+  end
+
+  def down
+    change_column_null    :tasks, :status, true
+    change_column_default :tasks, :status, nil
+    change_column_default :tasks, :progress, nil
+    # up で progress に NOT NULL を付けた場合はここで外す
+    # change_column_null    :tasks, :progress, true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_22_014322) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_23_023751) do
   create_table "tasks", force: :cascade do |t|
     t.string "title"
     t.text "description"
-    t.integer "status"
+    t.integer "status", default: 0, null: false
     t.datetime "deadline"
     t.integer "user_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
目的

フロントは「親直下は子4件まで」UIを実装済みだが、API側での制約が無く不整合の余地があった

新規作成時に status/progress 未指定だと 422 を踏むことがあり、デフォルト値で回避したい
→ サーバ側で一貫して P0-1 の整合性を担保し、UX とデータ品質を両立する



変更点

Task モデル

MAX_CHILDREN_PER_NODE = 4

children_count_limit バリデーション追加

発火条件: 新規作成または親付け替え（new_record? || will_save_change_to_parent_id?）

5件目になる操作を 422 で拒否（メッセージ: 親の子タスクは最大4件までです）

既存のロールアップ（子の progress 平均を親に反映）や depth 設定は維持

マイグレーション AddDefaultsToTasks

既存レコードの status/progress NULL を 0 で埋め

status に default=0 & NOT NULL、progress に default=0（必要なら将来 NOT NULL も検討）

仕様の再確認

親のみ site 必須、子は任意（現行のバリデーションを維持）

受け入れ条件 / 動作確認

親作成（site 必須）: 201

親に子1〜4件作成: すべて 201

5件目作成: 422 + エラーメッセージ（日本語 UI と整合）

付け替え（reparent）で 5件目になるケース: 422

作成時に status/progress を送らなくても 201 で作成され、既定値が入る（status=not_started, progress=0）