### PR TITLE
(backend): モデル整合性を固定（デフォルト/上限/ロールアップ）+ 総合テスト

### DIFF
--- a/backend/spec/models/tasks_filter_sort_spec.rb
+++ b/backend/spec/models/tasks_filter_sort_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Task, type: :model do
+  let(:user) { create(:user) }
+
+  describe ".filter_sort" do
+    it "deadline:asc は NULLS LAST になる" do
+      early = create(:task, user:, site: "A", deadline: Date.today + 1)
+      late  = create(:task, user:, site: "A", deadline: Date.today + 10)
+      none  = create(:task, user:, site: "A", deadline: nil)
+
+      ids = Task.filter_sort({ order_by: "deadline", dir: "asc" }, user:).pluck(:id)
+      expect(ids).to eq([early.id, late.id, none.id])
+    end
+
+    it "progress の範囲で絞り込める（min/max）" do
+      t0  = create(:task, user:, site: "A", progress: 0)
+      t50 = create(:task, user:, site: "A", progress: 50)
+      t90 = create(:task, user:, site: "A", progress: 90)
+
+      ids = Task.filter_sort({ progress_min: 10, progress_max: 60 }, user:).pluck(:id)
+      expect(ids).to match_array([t50.id])
+      expect(ids).not_to include(t0.id, t90.id)
+    end
+
+    it "status は文字列/数値どちらでも指定可能" do
+      s0 = create(:task, user:, site: "A", status: :not_started)
+      s1 = create(:task, user:, site: "A", status: :in_progress)
+      s2 = create(:task, user:, site: "A", status: :completed)
+
+      # 文字列
+      ids = Task.filter_sort({ status: ["in_progress"] }, user:).pluck(:id)
+      expect(ids).to eq([s1.id])
+
+      # 数値（enum の値）
+      ids2 = Task.filter_sort({ status: ["1"] }, user:).pluck(:id)
+      expect(ids2).to eq([s1.id])
+    end
+
+    it "parents_only=1 で親のみ（子は除外）" do
+      parent = create(:task, user:, site: "P")
+      _c1    = create(:task, user:, parent: parent)
+      _c2    = create(:task, user:, parent: parent)
+
+      ids = Task.filter_sort({ parents_only: "1" }, user:).pluck(:id)
+      expect(ids).to eq([parent.id])
+    end
+
+    it "order_by=progress の昇降順" do
+        a = create(:task, user:, site: "A", progress: 20)
+        b = create(:task, user:, site: "A", progress: 80)
+        # progress は NOT NULL + default 0 のため、nilではなく 0 を検証
+        c = create(:task, user:, site: "A") # => progress はデフォルト 0
+  
+        asc  = Task.filter_sort({ order_by: "progress", dir: "asc" }, user:).pluck(:id)
+        desc = Task.filter_sort({ order_by: "progress", dir: "desc" }, user:).pluck(:id)
+  
+        # COALESCE(progress,0) で比較される実装に沿った期待値
+        expect(asc).to  eq([c.id, a.id, b.id]) # 0 -> 20 -> 80
+        expect(desc).to eq([b.id, a.id, c.id]) # 80 -> 20 -> 0
+    end
+  end
+end

--- a/backend/spec/requests/tasks_children_limit_spec.rb
+++ b/backend/spec/requests/tasks_children_limit_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Tasks children limit", type: :request do
+  let(:me) { create(:user) }
+
+  it "4件までは作成OK、5件目は422（エラーメッセージ含む）" do
+    parent = create(:task, user: me, site: "現場X") # 親は site 必須
+
+    1.upto(4) do |i|
+      post "/api/tasks",
+           params: { task: { title: "子#{i}", parent_id: parent.id } }.to_json,
+           headers: auth_headers_for(me).merge(json_headers)
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)["parent_id"]).to eq(parent.id)
+    end
+
+    # 5件目はNG
+    post "/api/tasks",
+         params: { task: { title: "子5", parent_id: parent.id } }.to_json,
+         headers: auth_headers_for(me).merge(json_headers)
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(JSON.parse(response.body)["errors"].join).to include("最大4件")
+  end
+
+  it "親付け替えで5件目になる場合も422" do
+    a = create(:task, user: me, site: "現場A")
+    b = create(:task, user: me, site: "現場B")
+    # A には既に4件
+    create_list(:task, 4, user: me, parent: a)
+    # B に1件作成 → A に付け替え
+    child = create(:task, user: me, parent: b, title: "子X")
+
+    patch "/api/tasks/#{child.id}",
+          params: { task: { parent_id: a.id } }.to_json,
+          headers: auth_headers_for(me).merge(json_headers)
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(JSON.parse(response.body)["errors"].join).to include("最大4件")
+  end
+end

--- a/backend/spec/requests/tasks_sites_spec.rb
+++ b/backend/spec/requests/tasks_sites_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Tasks sites endpoint", type: :request do
+  let(:me)   { create(:user) }
+  let(:them) { create(:user) }
+
+  it "/api/tasks/sites は 親タスクの site を distinct で返し、他人/子は除外" do
+    # 自分の親（重複含む）
+    create(:task, user: me, site: "現場Alpha")
+    create(:task, user: me, site: "現場Beta")
+    create(:task, user: me, site: "現場Alpha") # 重複は1件化される想定
+
+    # 親Gamma + 子（子は対象外。site 有無に関わらず除外される）
+    parent_gamma = create(:task, user: me, site: "現場Gamma")
+    create(:task, user: me, parent: parent_gamma)                    # 子（siteなし）
+    create(:task, user: me, parent: parent_gamma, site: "子だけのsite") # 子（siteあり）も除外
+
+    # 他人分は弾く
+    create(:task, user: them, site: "現場Zeta")
+
+    get "/api/tasks/sites", headers: auth_headers_for(me)
+
+    expect(response).to have_http_status(:ok)
+    arr = JSON.parse(response.body)
+    # コントローラは LOWER(site) ASC で並べ替え済み
+    expect(arr).to eq(%w[現場Alpha 現場Beta 現場Gamma])
+  end
+end


### PR DESCRIPTION
概要:

モデル制約: 親のみ site 必須、子直下最大4件、深さは4階層まで

デフォルト: status=not_started, progress=0（既存NULLをマイグレーションで埋め）

ロールアップ: 子progress変更/親付け替え/削除で親→祖先まで平均反映

一覧API: フィルタ（site/status/progress/parents_only）＆ソート（deadline/progress/created_at, NULLS LAST）

/api/tasks/sites: 親のsite候補を distinct で返す

テスト: モデル＋リクエストの総合カバレッジ、Factory・ヘルパ整備

結果: RSpec 全緑