### PR TITLE
Feat/frontend priority widget

### DIFF
--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -7,12 +7,12 @@ module Api
 
     def index
       tasks = Task.filter_sort(filter_params, user: current_user)
-      render json: tasks.select(SELECT_FIELDS)
+      render json: tasks.as_json(only: SELECT_FIELDS)
     end
 
     def priority
       tasks = current_user.tasks.priority_order
-      render json: tasks.select(SELECT_FIELDS)
+      render json: tasks.as_json(only: SELECT_FIELDS)
     end
 
     def show

--- a/frontend/src/features/priority/usePriorityTasks.ts
+++ b/frontend/src/features/priority/usePriorityTasks.ts
@@ -1,28 +1,17 @@
-// src/features/priority/usePriorityTasks.ts
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../lib/apiClient";
 import type { Task } from "../../types/task";
 
-// APIの揺れ（配列 or { tasks: [] }）を型で吸収
-type PriorityTasksResponse = Task[] | { tasks: Task[] };
-const normalize = (d: PriorityTasksResponse): Task[] =>
-  Array.isArray(d) ? d : d.tasks;
-
 async function fetchPriorityTasks(): Promise<Task[]> {
-  const { data } = await api.get<PriorityTasksResponse>("/tasks/priority");
-  return normalize(data);
+  const { data } = await api.get<Task[]>("/tasks/priority");
+  return data;
 }
 
-/** ログイン済みのときだけ enabled=true を渡して使う */
 export function usePriorityTasks(enabled = true) {
-  return useQuery<Task[], Error>({
+  return useQuery({
     queryKey: ["priorityTasks"],
     queryFn: fetchPriorityTasks,
     enabled,
     staleTime: 30_000,
-    refetchOnMount: "always",
-    refetchOnWindowFocus: "always",
-    refetchOnReconnect: "always",
-    retry: false,
   });
 }


### PR DESCRIPTION
## 目的
- 画面サイドに「優先タスク」（未完了・期限優先・最大5件）を常時表示し、バックエンドの /api/tasks/priority と挙動を統一する。

## 変更点
- usePriorityTasks: /api/tasks/priority を取得する React Query フックを追加
- PriorityTasksPanel:
  - 件数表示、期限(曜日)表示、進捗バーを実装
  - チェックボックスで完了⇄未完了をトグル（useUpdateTask と連携）
- 認証状態(authed)に応じて取得を有効化

## 動作確認
1. ログイン後、親タスクを作成（期限あり/未完了）
2. サイドの「優先タスク」に最大5件まで表示されること
3. チェック操作で完了となり、リストから外れること
4. 期限なしタスクは、期限ありより後ろに並ぶこと（API準拠）

## 補足
- 未完了へ戻す際に progress が 100% のまま残るのが気になる場合は、
  `in_progress` へ戻すときに `progress: 99` へ寄せる微修正を提案（コード内コメント参照）。
