### PR TITLE
feat(frontend): フィルターバーをAPI連動（site/ステータス/進捗/親のみ/並び替え・URL同期）

### DIFF
--- a/frontend/src/features/tasks/TaskFilterBar.tsx
+++ b/frontend/src/features/tasks/TaskFilterBar.tsx
@@ -1,134 +1,198 @@
-import { useMemo, useCallback } from "react";
+// src/features/tasks/TaskFilterBar.tsx
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { useSites } from "./useSites";
-import { readSiteHistory } from "../../lib/siteHistory";
+import { useSites } from "./useTasks";
+import { useDebouncedValue } from "../../hooks/useDebouncedValue";
 
-const STATUSES = ["not_started", "in_progress", "completed"] as const;
+const ALL_STATUS = ["not_started", "in_progress", "completed"] as const;
+type Status = typeof ALL_STATUS[number];
+
+const toArray = (v: string | string[] | null): string[] =>
+  v == null ? [] : Array.isArray(v) ? v : [v];
 
 export function TaskFilterBar() {
   const [sp, setSp] = useSearchParams();
-  const { data: serverSites = [] } = useSites(true);
-  const localSites = readSiteHistory();
-  const siteOptions = Array.from(
-    new Set([...localSites, ...serverSites])
-  ).slice(0, 50);
+  const { data: sites = [] } = useSites(true);
 
-  const filters = useMemo(
-    () => ({
-      site: sp.get("site") || "",
-      status: sp.getAll("status"),
-      progress_min: Number(sp.get("progress_min") ?? "0"),
-      progress_max: Number(sp.get("progress_max") ?? "100"),
+  // URL → 初期状態
+  const initial = useMemo(() => {
+    const status = sp.getAll("status");
+    return {
+      site: sp.get("site") ?? "",
+      status: status.length ? (status as Status[]) : ([] as Status[]),
+      progress_min: sp.get("progress_min") ?? "",
+      progress_max: sp.get("progress_max") ?? "",
       order_by: (sp.get("order_by") ?? "deadline") as
         | "deadline"
         | "progress"
         | "created_at",
       dir: (sp.get("dir") ?? "asc") as "asc" | "desc",
-      parents_only: sp.get("parents_only") ?? undefined,
-    }),
-    [sp]
+      parents_only: sp.get("parents_only") === "1",
+    };
+  }, [sp]);
+
+  const [site, setSite] = useState(initial.site);
+  const [status, setStatus] = useState<Status[]>(initial.status);
+  const [progressMin, setProgressMin] = useState(initial.progress_min);
+  const [progressMax, setProgressMax] = useState(initial.progress_max);
+  const [orderBy, setOrderBy] = useState(initial.order_by);
+  const [dir, setDir] = useState<"asc" | "desc">(initial.dir);
+  const [parentsOnly, setParentsOnly] = useState(initial.parents_only);
+
+  // 変更 → 300ms debounce → URL同期
+  const debounced = useDebouncedValue(
+    { site, status, progressMin, progressMax, orderBy, dir, parentsOnly },
+    300
   );
 
-  const patch = useCallback(
-    (obj: Record<string, string | string[] | number | undefined>) => {
-      // ★ 毎回“今のURL”から開始して競合を防ぐ
-      const curr = new URLSearchParams(window.location.search);
+  useEffect(() => {
+    const next = new URLSearchParams();
 
-      // 変更対象キーは一旦全削除してから入れ直す（配列対応）
-      Object.entries(obj).forEach(([k, v]) => {
-        curr.delete(k);
-        if (Array.isArray(v)) {
-          v.forEach((val) => curr.append(k, String(val)));
-        } else if (v !== "" && v !== undefined) {
-          curr.set(k, String(v));
-        }
-      });
+    if (debounced.site.trim()) next.set("site", debounced.site.trim());
+    debounced.status.forEach((s) => next.append("status", s));
+    if (debounced.progressMin !== "")
+      next.set("progress_min", String(debounced.progressMin));
+    if (debounced.progressMax !== "")
+      next.set("progress_max", String(debounced.progressMax));
+    if (debounced.orderBy) next.set("order_by", debounced.orderBy);
+    if (debounced.dir) next.set("dir", debounced.dir);
+    if (debounced.parentsOnly) next.set("parents_only", "1");
 
-      setSp(curr, { replace: false });
-    },
-    [setSp]
-  );
+    setSp(next, { replace: true });
+  }, [debounced, setSp]);
+
+  const toggleStatus = (s: Status) =>
+    setStatus((cur) =>
+      cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s]
+    );
+
+  const reset = () => {
+    setSite("");
+    setStatus([]);
+    setProgressMin("");
+    setProgressMax("");
+    setOrderBy("deadline");
+    setDir("asc");
+    setParentsOnly(false);
+  };
 
   return (
-    <div className="flex flex-wrap items-center gap-3 p-3 border rounded-xl">
-      <input
-        className="border rounded px-2 py-1"
-        placeholder="現場名(site)"
-        list="site-list"
-        value={filters.site}
-        onChange={(e) => patch({ site: e.target.value })}
-      />
-      <datalist id="site-list">
-        {siteOptions.map((s) => (
-          <option key={s} value={s} />
-        ))}
-      </datalist>
-
-      <label className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={filters.parents_only === "1"}
-          onChange={(e) =>
-            patch({ parents_only: e.target.checked ? "1" : undefined })
-          }
-        />
-        親のみ
-      </label>
-
-      <label className="flex items-center gap-2">
-        進捗 {filters.progress_min}%–{filters.progress_max}%
-        <input
-          type="number"
-          min={0}
-          max={100}
-          value={filters.progress_min}
-          onChange={(e) => patch({ progress_min: Number(e.target.value) })}
-          className="w-16 border rounded px-1 py-0.5"
-        />
-        <input
-          type="number"
-          min={0}
-          max={100}
-          value={filters.progress_max}
-          onChange={(e) => patch({ progress_max: Number(e.target.value) })}
-          className="w-16 border rounded px-1 py-0.5"
-        />
-      </label>
-
-      <div className="flex items-center gap-2">
-        {STATUSES.map((s) => {
-          const on = filters.status.includes(s);
-          return (
-            <button
-              key={s}
-              className={`px-2 py-1 rounded border ${on ? "font-bold" : ""}`}
-              onClick={() => {
-                const set = new Set(filters.status);
-                on ? set.delete(s) : set.add(s);
-                patch({ status: Array.from(set) });
-              }}
-            >
-              {s}
-            </button>
-          );
-        })}
+    <div className="mb-4 rounded-xl border p-3 bg-white/60 dark:bg-zinc-900/40">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-semibold">フィルター</h3>
+        <button
+          type="button"
+          onClick={reset}
+          className="text-sm underline decoration-dotted"
+          aria-label="フィルタをクリア"
+        >
+          クリア
+        </button>
       </div>
 
-      <select
-        value={`${filters.order_by}:${filters.dir}`}
-        onChange={(e) => {
-          const [order_by, dir] = e.target.value.split(":");
-          patch({ order_by, dir });
-        }}
-        className="border rounded px-2 py-1"
-      >
-        <option value="deadline:asc">期限 ↑</option>
-        <option value="deadline:desc">期限 ↓</option>
-        <option value="progress:asc">進捗 ↑</option>
-        <option value="progress:desc">進捗 ↓</option>
-        <option value="created_at:desc">新着 ↓</option>
-        <option value="created_at:asc">新着 ↑</option>
-      </select>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {/* site */}
+        <label className="block text-sm">
+          <span className="block text-xs text-gray-500 mb-1">現場</span>
+          <input
+            list="site-options"
+            className="w-full rounded border px-2 py-1"
+            value={site}
+            onChange={(e) => setSite(e.target.value)}
+            placeholder="現場名で絞り込み"
+          />
+          <datalist id="site-options">
+            {sites.map((s) => (
+              <option key={s} value={s} />
+            ))}
+          </datalist>
+        </label>
+
+        {/* status */}
+        <div className="text-sm">
+          <div className="text-xs text-gray-500 mb-1">ステータス</div>
+          <div className="flex gap-3">
+            {ALL_STATUS.map((s) => (
+              <label key={s} className="inline-flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={status.includes(s)}
+                  onChange={() => toggleStatus(s)}
+                />
+                <span className="capitalize">
+                  {s === "not_started"
+                    ? "未着手"
+                    : s === "in_progress"
+                    ? "進行中"
+                    : "完了"}
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* parents_only */}
+        <label className="inline-flex items-center gap-2 text-sm mt-5 md:mt-0">
+          <input
+            type="checkbox"
+            checked={parentsOnly}
+            onChange={(e) => setParentsOnly(e.target.checked)}
+          />
+          親タスクのみ
+        </label>
+
+        {/* progress */}
+        <div className="text-sm">
+          <div className="text-xs text-gray-500 mb-1">進捗(%)</div>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={0}
+              max={100}
+              className="w-20 rounded border px-2 py-1"
+              value={progressMin}
+              onChange={(e) => setProgressMin(e.target.value)}
+              placeholder="最小"
+            />
+            <span>〜</span>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              className="w-20 rounded border px-2 py-1"
+              value={progressMax}
+              onChange={(e) => setProgressMax(e.target.value)}
+              placeholder="最大"
+            />
+          </div>
+        </div>
+
+        {/* order_by / dir */}
+        <div className="text-sm">
+          <div className="text-xs text-gray-500 mb-1">並び替え</div>
+          <div className="flex gap-2">
+            <select
+              className="rounded border px-2 py-1"
+              value={orderBy}
+              onChange={(e) =>
+                setOrderBy(e.target.value as "deadline" | "progress" | "created_at")
+              }
+            >
+              <option value="deadline">期限</option>
+              <option value="progress">進捗</option>
+              <option value="created_at">作成日時</option>
+            </select>
+            <select
+              className="rounded border px-2 py-1"
+              value={dir}
+              onChange={(e) => setDir(e.target.value as "asc" | "desc")}
+            >
+              <option value="asc">昇順</option>
+              <option value="desc">降順</option>
+            </select>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 目的
タスク一覧のフィルタ・並び替えをバックエンドAPIと統一し、URL共有や再訪時の再現性を高める。

## 変更点
- useFilteredTasks / useSites を追加（/api/tasks・/api/tasks/sites 連動）
- TaskFilterBar を実装（URLクエリと双方向同期）
  - site（datalist）
  - status（未着手/進行中/完了）
  - progress_min / progress_max（0..100）
  - parents_only（親のみ表示）
  - order_by（deadline/progress/created_at） + dir（asc/desc）
- 一覧は URL 変更に追従して自動再フェッチ

## 動作確認
- クエリを操作→URLが更新され、/api/tasks に正しくパラメータ送出される
- 期限なしは `deadline NULLS LAST` の順序で後ろになる
- 親のみ（parents_only=1）で子が一覧から除外される
- URLを共有/再読込しても同じ絞り込み結果を再現できる

## リスク/補足
- 既存の useDebouncedValue(300ms) を利用し、過剰な再フェッチを抑制
