### PR TITLE
feat: reorder API（同一親内の並び替えをサーバ永続化／親またぎは 422）

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
         get :priority
         get :sites
       end
+      member do
+        patch :reorder
+      end
     end
   end
 end

--- a/frontend/src/features/tasks/api.ts
+++ b/frontend/src/features/tasks/api.ts
@@ -1,0 +1,7 @@
+// src/features/tasks/api.ts
+import api from "../../lib/apiClient";
+
+/** 同一親内の並び替えをサーバ永続化 */
+export async function reorderWithinParentApi(taskId: number, afterId: number | null) {
+  await api.patch(`/tasks/${taskId}/reorder`, {}, { params: { after_id: afterId } });
+}

--- a/frontend/src/features/tasks/inline/dndContext.tsx
+++ b/frontend/src/features/tasks/inline/dndContext.tsx
@@ -1,243 +1,244 @@
 // src/features/tasks/inline/dndContext.tsx
 import React, {
-    createContext,
-    useCallback,
-    useContext,
-    useEffect,
-    useMemo,
-    useState,
-  } from "react";
-  import type { Task } from "../../../types/task";
-  
-  type DndState = {
-    draggingId: number | null;
-    draggingParentId: number | null;
-    draggingDepth: number | null;
-  };
-  
-  type Ctx = {
-    state: DndState;
-    onDragStart: (task: Task, depth: number) => void;
-    onDragEnd: () => void;
-  
-    // 親またぎ不可（同一親だけ true）
-    canAcceptIntoParent: (parentId: number | null) => boolean;
-  
-    // 同一親内の並べ替え（UIローカル）
-    reorderWithinParent: (
-      parentId: number | null,
-      movingId: number,
-      afterId: number | null
-    ) => void;
-  
-    // 親またぎ移動は未対応（no-op）
-    moveAcrossParents: (args: {
-      fromPid: number | null;
-      toPid: number | null;
-      movingId: number;
-      afterId: number | null;
-    }) => void;
-  
-    // 表示順の取得（プロバイダが保持する順に並べる）
-    getOrderedChildren: (parentId: number, children: Task[]) => Task[];
-  
-    // サーバから受け取った“現在の並び”を登録
-    registerChildren: (parentId: number | null, childIds: number[]) => void;
-  };
-  
-  const C = createContext<Ctx | null>(null);
-  
-  export function useInlineDnd() {
-    const ctx = useContext(C);
-    if (!ctx) throw new Error("useInlineDnd must be used inside provider");
-    return ctx;
-  }
-  
-  // ---- helpers ----
-  const keyOf = (pid: number | null) => (pid == null ? "root" : `p:${pid}`);
-  
-  const eqArray = (a?: number[], b?: number[]) => {
-    if (!a || !b) return false;
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-    return true;
-  };
-  
-  export function InlineDndProvider({ children }: { children: React.ReactNode }) {
-    const [state, setState] = useState<DndState>({
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { Task } from "../../../types/task";
+import { useQueryClient } from "@tanstack/react-query";
+import { reorderWithinParentApi } from "../api";
+
+type DndState = {
+  draggingId: number | null;
+  draggingParentId: number | null;
+  draggingDepth: number | null;
+};
+
+type Ctx = {
+  state: DndState;
+  onDragStart: (task: Task, depth: number) => void;
+  onDragEnd: () => void;
+
+  // 親またぎ不可（同一親だけ true）
+  canAcceptIntoParent: (parentId: number | null) => boolean;
+
+  // 同一親内の並べ替え（UIローカル）
+  reorderWithinParent: (
+    parentId: number | null,
+    movingId: number,
+    afterId: number | null
+  ) => void;
+
+  // 親またぎ移動は未対応（no-op）
+  moveAcrossParents: (args: {
+    fromPid: number | null;
+    toPid: number | null;
+    movingId: number;
+    afterId: number | null;
+  }) => void;
+
+  // 表示順の取得（プロバイダが保持する順に並べる）
+  getOrderedChildren: (parentId: number, children: Task[]) => Task[];
+
+  // サーバから受け取った“現在の並び”を登録
+  registerChildren: (parentId: number | null, childIds: number[]) => void;
+};
+
+const C = createContext<Ctx | null>(null);
+
+export function useInlineDnd() {
+  const ctx = useContext(C);
+  if (!ctx) throw new Error("useInlineDnd must be used inside provider");
+  return ctx;
+}
+
+// ---- helpers ----
+const keyOf = (pid: number | null) => (pid == null ? "root" : `p:${pid}`);
+
+const eqArray = (a?: number[], b?: number[]) => {
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
+
+export function InlineDndProvider({ children }: { children: React.ReactNode }) {
+    const [state, setState] = useState<DndState>({ draggingId: null, draggingParentId: null, draggingDepth: null });
+    const [orderMap, setOrderMap] = useState<Record<string, number[]>>({});
+    const qc = useQueryClient();
+
+  // ドラッグ中フラグ（右ペイン等の当たり判定を殺すためのグローバルフラグ）
+  useEffect(() => {
+    document.body.classList.toggle("is-dragging", !!state.draggingId);
+    if (!state.draggingId) document.body.classList.remove("pre-drag");
+    return () => {
+      document.body.classList.remove("is-dragging");
+      document.body.classList.remove("pre-drag");
+    };
+  }, [state.draggingId]);
+
+  // ★ Chrome keep-alive：ドラッグ中は常に「どこか」が preventDefault する
+  useEffect(() => {
+    const onDragOver = (e: DragEvent) => {
+      if (!state.draggingId) return;
+      // これが無いと、最初の dragover までに対象が居ないケースで即 dragend になる
+      e.preventDefault();
+    };
+    window.addEventListener("dragover", onDragOver as any, {
+      passive: false,
+      capture: true,
+    });
+    return () =>
+      window.removeEventListener("dragover", onDragOver as any, true);
+  }, [state.draggingId]);
+
+  // ★ Playwright/ブラウザ差対策：即時 set + 次フレームでも再度 set
+  const onDragStart = useCallback((task: Task, depth: number) => {
+    const pid = task.parent_id ?? null;
+    const next = {
+      draggingId: task.id,
+      draggingParentId: pid,
+      draggingDepth: depth,
+    };
+    setState(next);
+    requestAnimationFrame(() => setState(next));
+  }, []);
+
+  const onDragEnd = useCallback(() => {
+    const cleared = {
       draggingId: null,
       draggingParentId: null,
       draggingDepth: null,
-    });
-  
-    // 親IDごとの“子IDの順序”を UI ローカルに保持
-    const [orderMap, setOrderMap] = useState<Record<string, number[]>>({});
-  
-    // ドラッグ中フラグ（右ペイン等の当たり判定を殺すためのグローバルフラグ）
-    useEffect(() => {
-      document.body.classList.toggle("is-dragging", !!state.draggingId);
-      if (!state.draggingId) document.body.classList.remove("pre-drag");
-      return () => {
-        document.body.classList.remove("is-dragging");
-        document.body.classList.remove("pre-drag");
-      };
-    }, [state.draggingId]);
-  
-    // ★ Chrome keep-alive：ドラッグ中は常に「どこか」が preventDefault する
-    useEffect(() => {
-      const onDragOver = (e: DragEvent) => {
-        if (!state.draggingId) return;
-        // これが無いと、最初の dragover までに対象が居ないケースで即 dragend になる
-        e.preventDefault();
-      };
-      window.addEventListener("dragover", onDragOver as any, {
-        passive: false,
-        capture: true,
+    };
+    setState(cleared);
+    requestAnimationFrame(() => setState(cleared));
+  }, []);
+
+  const canAcceptIntoParent = useCallback(
+    (parentId: number | null) => state.draggingParentId === parentId,
+    [state.draggingParentId]
+  );
+
+  // サーバから受け取った現在の並びを登録
+  // 集合が同じなら “順序差” はローカル優先（上書きしない）
+  const registerChildren = useCallback(
+    (parentId: number | null, childIds: number[]) => {
+      console.log("[REGISTER]", { parentId, childIds });
+      const k = keyOf(parentId);
+      setOrderMap((prev) => {
+        const current = prev[k];
+        if (!current) return { ...prev, [k]: childIds.slice() };
+
+        const sameMembers =
+          current.length === childIds.length &&
+          current.every((id) => childIds.includes(id));
+        if (!sameMembers) return { ...prev, [k]: childIds.slice() };
+
+        return prev; // 集合が同じ＝ローカル順を維持
       });
-      return () =>
-        window.removeEventListener("dragover", onDragOver as any, true);
-    }, [state.draggingId]);
-  
-    // ★ Playwright/ブラウザ差対策：即時 set + 次フレームでも再度 set
-    const onDragStart = useCallback((task: Task, depth: number) => {
-      const pid = task.parent_id ?? null;
-      const next = {
-        draggingId: task.id,
-        draggingParentId: pid,
-        draggingDepth: depth,
-      };
-      setState(next);
-      requestAnimationFrame(() => setState(next));
-    }, []);
-  
-    const onDragEnd = useCallback(() => {
-      const cleared = {
-        draggingId: null,
-        draggingParentId: null,
-        draggingDepth: null,
-      };
-      setState(cleared);
-      requestAnimationFrame(() => setState(cleared));
-    }, []);
-  
-    const canAcceptIntoParent = useCallback(
-      (parentId: number | null) => state.draggingParentId === parentId,
-      [state.draggingParentId]
-    );
-  
-    // サーバから受け取った現在の並びを登録
-    // 集合が同じなら “順序差” はローカル優先（上書きしない）
-    const registerChildren = useCallback(
-      (parentId: number | null, childIds: number[]) => {
-        console.log("[REGISTER]", { parentId, childIds });
-        const k = keyOf(parentId);
-        setOrderMap((prev) => {
-          const current = prev[k];
-          if (!current) return { ...prev, [k]: childIds.slice() };
-  
-          const sameMembers =
-            current.length === childIds.length &&
-            current.every((id) => childIds.includes(id));
-          if (!sameMembers) return { ...prev, [k]: childIds.slice() };
-  
-          return prev; // 集合が同じ＝ローカル順を維持
-        });
-      },
-      []
-    );
-  
-    // 同一親内の並べ替え：movingId を afterId の直後に入れる
-    const reorderWithinParent = useCallback(
-      (parentId: number | null, movingId: number, afterId: number | null) => {
-        const k = keyOf(parentId);
-        setOrderMap((prev) => {
-          const current = prev[k] ?? [];
-          console.log("[REORDER start]", {
-            k,
-            current: current.slice(),
-            movingId,
-            afterId,
-          });
-  
-          // --- フォールバック初期化：未登録でも動く ---
-          let base = current.slice();
-          if (base.length === 0) {
-            console.warn("[REORDER] current is empty. init base with movingId");
-            base = [movingId];
-          } else if (!base.includes(movingId)) {
-            console.warn("[REORDER] movingId not in current. append movingId");
-            base = [...base, movingId];
+    },
+    []
+  );
+
+  // ★ 同一親内の並べ替え：UI反映 → API → 成功でinvalidate / 失敗でロールバック
+  const reorderWithinParent = useCallback(
+    (parentId: number | null, movingId: number, afterId: number | null) => {
+      const k = keyOf(parentId);
+
+      // 直前の配列と次の配列を捕捉しておく（失敗時ロールバック用）
+      let prevArr: number[] | undefined;
+      let nextArr: number[] | undefined;
+
+      setOrderMap((prev) => {
+        const current = prev[k] ?? [];
+        prevArr = current;
+
+        // --- 既存ロジック（フォールバック初期化含む） ---
+        let base = current.slice();
+        if (base.length === 0) base = [movingId];
+        else if (!base.includes(movingId)) base = [...base, movingId];
+
+        const next = base.filter((id) => id !== movingId);
+        const idx = afterId == null || afterId < 0 ? -1 : next.indexOf(afterId);
+        const insertAt = Math.max(0, idx + 1);
+        next.splice(insertAt, 0, movingId);
+        nextArr = next;
+
+        if (eqArray(current, next)) return prev;
+        return { ...prev, [k]: next };
+      });
+
+      // 非同期でサーバ永続化 → 成功なら再取得、失敗ならロールバック
+      (async () => {
+        try {
+          await reorderWithinParentApi(movingId, afterId);
+          await qc.invalidateQueries({ queryKey: ["tasks"] });
+        } catch (e) {
+          // 失敗：UIを元の順序に戻す
+          if (prevArr) {
+            setOrderMap((prev) => ({ ...prev, [k]: prevArr! }));
           }
-  
-          const next = base.filter((id) => id !== movingId);
-          const idx = afterId == null || afterId < 0 ? -1 : next.indexOf(afterId);
-          const insertAt = Math.max(0, idx + 1);
-          next.splice(insertAt, 0, movingId);
-  
-          console.log("[REORDER next]", { k, next, insertAt });
-          if (eqArray(current, next)) {
-            console.log("[REORDER no-change]", { k });
-            return prev;
-          }
-          const out = { ...prev, [k]: next };
-          console.log("[REORDER commit]", out);
-          return out;
-        });
-      },
-      []
-    );
-  
-    const moveAcrossParents = useCallback((_args: any) => {
-      /* 親またぎ不可なので no-op */
-    }, []);
-  
-    const getOrderedChildren = useCallback(
-        (parentId: number | null, children: Task[]) => {
-          const k = keyOf(parentId);
-          const ord = orderMap[k];
-          if (!ord || ord.length === 0) return children;
-      
-          const pos = new Map<number, number>();
-          ord.forEach((id, i) => pos.set(id, i));
-          const withPos = children.map((c) => ({
-            c,
-            p: pos.get(c.id) ?? Number.MAX_SAFE_INTEGER,
-          }));
-          withPos.sort((a, b) => a.p - b.p);
-          return withPos.map((x) => x.c);
-        },
-        [orderMap]
-      );
-  
-    // （任意）デバッグ用：現在の orderMap を覗けるように
-    useEffect(() => {
-      // @ts-ignore
-      window.__orderMap = orderMap;
-    }, [orderMap]);
-  
-    const value = useMemo(
-      () => ({
-        state,
-        onDragStart,
-        onDragEnd,
-        canAcceptIntoParent,
-        reorderWithinParent,
-        moveAcrossParents,
-        getOrderedChildren,
-        registerChildren,
-      }),
-      [
-        state,
-        onDragStart,
-        onDragEnd,
-        canAcceptIntoParent,
-        reorderWithinParent,
-        moveAcrossParents,
-        getOrderedChildren,
-        registerChildren,
-      ]
-    );
-  
-    return <C.Provider value={value}>{children}</C.Provider>;
-  }
-  
+          // 任意：開発中の可視化
+          // console.warn("[REORDER persist failed]", e);
+        }
+      })();
+    },
+    [qc]
+  );
+
+  const moveAcrossParents = useCallback((_args: any) => {
+    /* 親またぎ不可なので no-op */
+  }, []);
+
+  const getOrderedChildren = useCallback(
+    (parentId: number | null, children: Task[]) => {
+      const k = keyOf(parentId);
+      const ord = orderMap[k];
+      if (!ord || ord.length === 0) return children;
+
+      const pos = new Map<number, number>();
+      ord.forEach((id, i) => pos.set(id, i));
+      const withPos = children.map((c) => ({
+        c,
+        p: pos.get(c.id) ?? Number.MAX_SAFE_INTEGER,
+      }));
+      withPos.sort((a, b) => a.p - b.p);
+      return withPos.map((x) => x.c);
+    },
+    [orderMap]
+  );
+
+  // （任意）デバッグ用：現在の orderMap を覗けるように
+  useEffect(() => {
+    // @ts-ignore
+    window.__orderMap = orderMap;
+  }, [orderMap]);
+
+  const value = useMemo(
+    () => ({
+      state,
+      onDragStart,
+      onDragEnd,
+      canAcceptIntoParent,
+      reorderWithinParent,
+      moveAcrossParents,
+      getOrderedChildren,
+      registerChildren,
+    }),
+    [
+      state,
+      onDragStart,
+      onDragEnd,
+      canAcceptIntoParent,
+      reorderWithinParent,
+      moveAcrossParents,
+      getOrderedChildren,
+      registerChildren,
+    ]
+  );
+
+  return <C.Provider value={value}>{children}</C.Provider>;
+}

--- a/frontend/tests/.auth/storage.json
+++ b/frontend/tests/.auth/storage.json
@@ -10,7 +10,7 @@
         },
         {
           "name": "expiry",
-          "value": "1757979097"
+          "value": "1757981830"
         },
         {
           "name": "uid",
@@ -18,11 +18,11 @@
         },
         {
           "name": "client",
-          "value": "KGoRBRQmicClDF7_pPSUkw"
+          "value": "cm_44828vQ0uUwDTaiPJ5Q"
         },
         {
           "name": "access-token",
-          "value": "dy1eK3R7DI7sLV6-7JQZHw"
+          "value": "E9Q95vybPkwY3XHiL9TORw"
         },
         {
           "name": "token-type",

--- a/frontend/tests/reorder-api-guard.spec.ts
+++ b/frontend/tests/reorder-api-guard.spec.ts
@@ -1,0 +1,45 @@
+// tests/reorder-api-guard.spec.ts
+import { test, expect } from "@playwright/test";
+import { ensureAuthTokens, createTaskViaApi } from "./helpers";
+
+test.use({ storageState: "tests/.auth/e2e.json" });
+
+test("親またぎ reorder は 422 を返す", async ({ page }) => {
+  await page.goto("/tasks");
+  await ensureAuthTokens(page); // localStorage に DTA トークンを入れる
+
+  const p1 = await createTaskViaApi(page, { title: `P1-${Date.now()}`, site: "E2E", parent_id: null });
+  const a  = await createTaskViaApi(page, { title: `A-${Date.now()}`,  parent_id: p1.id });
+  const p2 = await createTaskViaApi(page, { title: `P2-${Date.now()}`, site: "E2E", parent_id: null });
+  const x  = await createTaskViaApi(page, { title: `X-${Date.now()}`,  parent_id: p2.id });
+
+  // ← ブラウザ側の fetch で localStorage の DTA ヘッダを付けて叩く
+  const result = await page.evaluate(async ({ aId, xId }) => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    const at = localStorage.getItem("access-token");
+    const client = localStorage.getItem("client");
+    const uid = localStorage.getItem("uid");
+    if (at && client && uid) {
+      headers["access-token"] = at;
+      headers["client"] = client;
+      headers["uid"] = uid;
+    }
+
+    const res = await fetch(`/api/tasks/${aId}/reorder?after_id=${xId}`, {
+      method: "PATCH",
+      headers,
+      credentials: "same-origin",
+    });
+
+    let body: any = null;
+    try { body = await res.json(); } catch { body = await res.text(); }
+
+    return { status: res.status, body };
+  }, { aId: a.id, xId: x.id });
+
+  // デバッグ時に中身が見やすいように失敗メッセージを含める
+  expect(result.status, `unexpected: ${JSON.stringify(result.body)}`).toBe(422);
+});


### PR DESCRIPTION
## 概要
同一親内の並び替えをサーバ側で永続化するエンドポイントを追加。親またぎの不正な並び替えは 422 を返し、DB の整合性を担保します。

## 変更点
- Routing: `PATCH /api/tasks/:id/reorder?after_id=...` を追加（member）。
- Controller: `TasksController#reorder` を公開。
  - after_id=nil で先頭移動。
  - 兄弟のみ許可。親またぎは `422 Unprocessable Entity`。
  - 成功時は `204 No Content`。
- 並びの安定性: `index` は従来通り primary ソート + `parent_id, position`。
- E2E: 親またぎ Reorder が 422 を返すことを検証する `reorder-api-guard.spec.ts` を追加。

## API 仕様
- **Endpoint**: `PATCH /api/tasks/:id/reorder?after_id=:task_id_or_nil`
- **動作**: 同一親の兄弟 `after_id` の直後に `id` を移動。`after_id` 省略/NULL で先頭。
- **レスポンス**: 204（成功）/ 422（親またぎ）/ 404（未存在 or 他ユーザ）。

## 動作確認
1. 親A配下に t1,t2,t3 を作成。
2. `PATCH /api/tasks/:t1/reorder?after_id=:t2` → 204、`t2,t1,t3` に。
3. 親Bの子xを `after_id=x` で指定 → 422。

## 互換性
破壊的変更なし。既存の一覧表示順は維持。

