### PR TITLE
feat(filter-progress): 進捗レンジのフィルタUI + URL同期 + E2E

### DIFF
--- a/frontend/tests/.auth/e2e.json
+++ b/frontend/tests/.auth/e2e.json
@@ -2,7 +2,7 @@
   "cookies": [
     {
       "name": "_backend_session",
-      "value": "oCGUbE9w3JZBArMwPwWQb1aoEzTFr5c%2Fuq1tz%2BSGprL4HY8AHXEwIEYhd9OfUdNxrv41BvnSmLmoXwv5CRACVA9Ji4fd9yeM43GEuK4%2Fpl6Wfw5dJDTYQLUH9IXRHgyRPbZKlo55B41pLzqwZVH4h13XJStjRPtvFlO1mq0sQyVCIolCaU5ke%2FtXdt%2BcwqSmOdTZpWyeOTikbghmQzWBhLvQ%2FXpKDkLv9tn1Gv%2FIrpysa1xeKvyIC4LSmEfZp7sdk50sna1pExhSgnMnx4a5vgPSaOyX8%2Ff8Y9fWYJucNDPRMNbBK8j2RjzpUgXEYYT28wAQWvQO91Q3bHH%2Bn6Sha4xYGXC6PpG4vyd4MMVsipuTyB8PhGU1P6jTgYZGL9q1SPK3n4kB5qabfKUF6Jhab6kH34ef8AGRKabROzVB8yeoVlYRh%2FLvzbcKODMpilQySM%2F%2FOldNCdb5J2KLDcI43djkYawAa1snK5ycAeF5iuCZAGVBTTDX9kbvvEM9r0cN0bO91q0Mmxc%3D--I0T5bw5xmKw5c5w%2F--%2BkUCHzBieP4Jc197zD9xJA%3D%3D",
+      "value": "5dzk1kMtijxtHm1cWGEziDQLbW7Zu1lsikjDqe2rkcqm%2BNvgTwqcXR%2BRqpkRGK6ISfbvYmdzrRqhKmKqtfy7ZBOR2ku6piHSa1BaLAVU02QXog8bdTFmeVTnRzxO3USPDGDF0Va8iXFdGdnX%2BGW5h7hKglDK4rk4zEuVDCAxBnQPEaP1HHQ2J928m4FKQlSSS584aSDsyB1SmIeJ2tJn%2FuSjxxyk0R6CGCKBTzSr8U3pxahfFKzwXUTja98pBeCMkSbnG8HPqOQKtvU3Jx5R7VsMu%2BWk56g%2BlXim%2FpJJGNL2JAcL%2BU%2FZ8d658zqiNVIszCLb6RPCETl6E6Ysg4b2xNJUR9rvaLs50nS4O34DBxEAC36TMspadH00sWQ%2FhdgrXSRGuOcZ%2BiOr9EYoWdqUdUMF05e4qMiMO1NpduWzv2stcaCiCfkwxkpbZcpNsbG%2BpKEh5DTRlhct4Ttyx8obljO6HK9nsOF7x3jZ8%2FtF89CP%2F%2Brzxn5N7r8I30dQHcl4poVRlXHrB%2FM%3D--FVVaCZASqfO4yXLr--H6cZV%2FK8d7eDnB%2BeX7lRmA%3D%3D",
       "domain": "localhost",
       "path": "/",
       "expires": -1,
@@ -16,16 +16,20 @@
       "origin": "http://localhost:5173",
       "localStorage": [
         {
-          "name": "client",
-          "value": "LdRCvS_ahMx_Erbab_PLWg"
-        },
-        {
-          "name": "access-token",
-          "value": "B4dWVL2Lq5GEDj3rW588aQ"
+          "name": "theme",
+          "value": "light"
         },
         {
           "name": "uid",
           "value": "e2e@example.com"
+        },
+        {
+          "name": "client",
+          "value": "VbpjT0mHmMw43c3i7q6uhg"
+        },
+        {
+          "name": "access-token",
+          "value": "buvDMWG40ZMLuB9DvGd1ug"
         }
       ]
     }

--- a/frontend/tests/.auth/setup.spec.ts
+++ b/frontend/tests/.auth/setup.spec.ts
@@ -4,74 +4,62 @@ import { test, expect } from "@playwright/test";
 const EMAIL = process.env.E2E_EMAIL ?? "e2e@example.com";
 const PASSWORD = process.env.E2E_PASSWORD ?? "password";
 
+test.setTimeout(90_000);
+
 test("login and save storage", async ({ page, context }) => {
-  // まず /login を開いて同一オリジンで実行
+  await context.clearCookies();
+  await page.addInitScript(() => {
+    try { localStorage.clear(); sessionStorage.clear(); } catch {}
+  });
+
+  // 同一オリジンに乗る
   await page.goto("/login");
 
-  // 1) プログラムでサインイン（失敗なら登録→再サインイン）
+  // --- 1) プログラムログイン（失敗したら UI フォールバック） ---
   const result = await page.evaluate(async ({ email, password }) => {
     async function signIn() {
-      const res = await fetch("/api/auth/sign_in", {
+      return fetch("/api/auth/sign_in", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", accept: "application/json" },
         body: JSON.stringify({ email, password }),
+        credentials: "same-origin",
       });
-      return res;
     }
     async function signUp() {
-      // devise_token_auth 想定
-      const res = await fetch("/api/auth", {
+      return fetch("/api/auth", {
         method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          email,
-          password,
-          password_confirmation: password,
-        }),
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify({ email, password, password_confirmation: password }),
+        credentials: "same-origin",
       });
-      return res;
     }
 
-    // サインイン試行
     let res = await signIn();
-
-    // 401 ならユーザー作成を試みてから再サインイン
     if (res.status === 401) {
       await signUp().catch(() => undefined);
       res = await signIn();
     }
+    if (!res.ok) return { ok: false, status: res.status };
 
-    if (!res.ok) {
-      return { ok: false, status: res.status, note: "sign_in failed" };
-    }
-
-    // レスポンスヘッダからトークン取得
     const at = res.headers.get("access-token");
     const client = res.headers.get("client");
     const uid = res.headers.get("uid");
     const expiry = res.headers.get("expiry");
     const tokenType = res.headers.get("token-type");
+    if (!at || !client || !uid) return { ok: false, status: 200 };
 
-    if (!at || !client || !uid) {
-      return { ok: false, status: 200, note: "missing headers" };
-    }
-
-    // アプリが読むキーに保存（AuthContext 準拠）
     localStorage.setItem("access-token", at);
     localStorage.setItem("client", client);
     localStorage.setItem("uid", uid);
     if (expiry) localStorage.setItem("expiry", expiry);
     if (tokenType) localStorage.setItem("token-type", tokenType);
 
-    // AuthProvider が拾うイベントを発火（実装済みの on 'auth:refresh' を使用）
+    // /login 上でも一度通知
     window.dispatchEvent(new Event("auth:refresh"));
-
     return { ok: true };
   }, { email: EMAIL, password: PASSWORD });
 
-  // 2) フォールバック（万一ヘッダ読めない環境用）：UI ログイン
   if (!result?.ok) {
-    // 可能性のあるセレクタを総当たり（存在するものが使われる）
     const emailSel = 'input[type="email"], input[name="email"], [data-testid="login-email"]';
     const passSel  = 'input[type="password"], input[name="password"], [data-testid="login-password"]';
     await page.locator(emailSel).first().fill(EMAIL);
@@ -79,11 +67,39 @@ test("login and save storage", async ({ page, context }) => {
     await page.getByRole("button", { name: /ログイン|Sign\s*In|Log\s*in/i }).click();
   }
 
-  // 3) タスクページへ
-  await page.goto("/tasks");
-  // 見出し or URL でログイン成功を確認
-  await expect(page.getByText("タスク一覧ページ")).toBeVisible({ timeout: 15_000 });
+  // --- 2) /tasks へ。Provider マウント後に再通知し、/api/tasks の 200 を待つ ---
+  await page.goto("/tasks", { waitUntil: "domcontentloaded" });
+  await page.evaluate(() => window.dispatchEvent(new Event("auth:refresh")));
 
-  // 4) ストレージを保存（以降の auth プロジェクトが使う）
-  await context.storageState({ path: "tests/.auth/storage.json" });
+  const reachedViaApi = await page
+    .waitForResponse(
+      r => r.url().includes("/api/tasks") && r.request().method() === "GET" && r.status() === 200,
+      { timeout: 15_000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+
+  // --- 3) まだなら UI ログインのフォールバックを実施 ---
+  if (!reachedViaApi || page.url().includes("/login")) {
+    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    const emailSel = 'input[type="email"], input[name="email"], [data-testid="login-email"]';
+    const passSel  = 'input[type="password"], input[name="password"], [data-testid="login-password"]';
+    await page.locator(emailSel).first().fill(EMAIL);
+    await page.locator(passSel).first().fill(PASSWORD);
+    await page.getByRole("button", { name: /ログイン|Sign\s*In|Log\s*in/i }).click();
+    await page.waitForURL(/\/tasks(\?.*)?$/, { timeout: 15_000 }).catch(() => {});
+  }
+
+  // --- 4) 最終到達の確定（どれかが見えればOK） ---
+  const reached = await Promise.any([
+    page.waitForSelector('[data-testid="task-list-root"]', { state: "attached", timeout: 8_000 }).then(() => true),
+    page.getByTestId("filter-bar").waitFor({ state: "visible", timeout: 8_000 }).then(() => true),
+    page.getByRole("heading", { name: "タスク一覧ページ" }).waitFor({ state: "visible", timeout: 8_000 }).then(() => true),
+  ]).catch(() => false);
+
+  expect(reached).toBeTruthy();
+  await page.waitForLoadState("networkidle");
+
+  // --- 5) ストレージ保存（以降の auth プロジェクトが利用） ---
+  await context.storageState({ path: "tests/.auth/e2e.json" });
 });

--- a/frontend/tests/.auth/storage.json
+++ b/frontend/tests/.auth/storage.json
@@ -10,7 +10,7 @@
         },
         {
           "name": "expiry",
-          "value": "1757982849"
+          "value": "1757983803"
         },
         {
           "name": "uid",
@@ -18,11 +18,11 @@
         },
         {
           "name": "client",
-          "value": "HeeMnHIzq5dbmQ-BgVQ7Lw"
+          "value": "sID5mGWiYWJtgESt-nWGLA"
         },
         {
           "name": "access-token",
-          "value": "PxgyQeUvZwMdB2HrTDPv_A"
+          "value": "x7WQNVwsqMstVTH8o5e1tQ"
         },
         {
           "name": "token-type",

--- a/frontend/tests/dnd/_helpers.ts
+++ b/frontend/tests/dnd/_helpers.ts
@@ -10,44 +10,97 @@ type NewTask = {
   description?: string | null;
 };
 
-export async function apiCreateTask(page: Page, task: NewTask) {
-  const json = await page.evaluate(async (t) => {
-    const at = localStorage.getItem("access-token");
-    const client = localStorage.getItem("client");
-    const uid = localStorage.getItem("uid");
-    const res = await fetch("/api/tasks", {
-      method: "POST",
-      headers: {
+export async function apiCreateTask(page, attrs: any) {
+    return await page.evaluate(async (body) => {
+      // localStorage のトークンをヘッダに乗せる
+      const hdrs: Record<string, string> = {
         "content-type": "application/json",
-        "access-token": at ?? "",
-        client: client ?? "",
-        uid: uid ?? "",
-      },
-      body: JSON.stringify({ task: t }),
-    });
-    const data = await res.json();
-    if (!res.ok) throw new Error(`create failed: ${JSON.stringify(data)}`);
-    return data;
-  }, task);
-  return json as { id: number; title: string; parent_id: number | null };
-}
+        accept: "application/json",
+      };
+      const at = localStorage.getItem("access-token");
+      const client = localStorage.getItem("client");
+      const uid = localStorage.getItem("uid");
+      const expiry = localStorage.getItem("expiry");
+      const tokenType = localStorage.getItem("token-type") || "Bearer";
+      if (at && client && uid) {
+        hdrs["access-token"] = at;
+        hdrs["client"] = client;
+        hdrs["uid"] = uid;
+        if (expiry) hdrs["expiry"] = expiry;
+        if (tokenType) hdrs["token-type"] = tokenType;
+      }
+  
+      const res = await fetch("/api/tasks", {
+        method: "POST",
+        headers: hdrs,
+        body: JSON.stringify({ task: body }),
+        credentials: "same-origin",
+      });
+  
+      if (res.status === 401) {
+        throw new Error(
+          `create failed: ${JSON.stringify({ errors: ["You need to sign in or sign up before continuing."] })}`
+        );
+      }
+      if (!res.ok) {
+        const t = await res.text().catch(() => "");
+        throw new Error(`create failed: ${t}`);
+      }
+  
+      // トークンローテーション対応：返ってきたら保存
+      const nat = res.headers.get("access-token");
+      if (nat) localStorage.setItem("access-token", nat);
+      const nclient = res.headers.get("client");
+      if (nclient) localStorage.setItem("client", nclient);
+      const nuid = res.headers.get("uid");
+      if (nuid) localStorage.setItem("uid", nuid);
+      const nexpiry = res.headers.get("expiry");
+      if (nexpiry) localStorage.setItem("expiry", nexpiry);
+      const nt = res.headers.get("token-type");
+      if (nt) localStorage.setItem("token-type", nt);
+  
+      return await res.json();
+    }, attrs);
+  }
 
-export async function apiDeleteTask(page: Page, id: number) {
-  await page.evaluate(async (tid) => {
-    const at = localStorage.getItem("access-token");
-    const client = localStorage.getItem("client");
-    const uid = localStorage.getItem("uid");
-    const res = await fetch(`/api/tasks/${tid}`, {
-      method: "DELETE",
-      headers: {
-        "access-token": at ?? "",
-        client: client ?? "",
-        uid: uid ?? "",
-      },
-    });
-    if (!res.ok) throw new Error(`delete failed: ${res.status}`);
-  }, id);
-}
+  export async function apiDeleteTask(page: Page, id: number) {
+    await page.evaluate(async (tid) => {
+      const hdrs: Record<string, string> = {
+        accept: "application/json",
+      };
+      const at = localStorage.getItem("access-token");
+      const client = localStorage.getItem("client");
+      const uid = localStorage.getItem("uid");
+      const expiry = localStorage.getItem("expiry");
+      const tokenType = localStorage.getItem("token-type") || "Bearer";
+      if (at && client && uid) {
+        hdrs["access-token"] = at;
+        hdrs["client"] = client;
+        hdrs["uid"] = uid;
+        if (expiry) hdrs["expiry"] = expiry;
+        if (tokenType) hdrs["token-type"] = tokenType;
+      }
+  
+      const res = await fetch(`/api/tasks/${tid}`, {
+        method: "DELETE",
+        headers: hdrs,
+        credentials: "same-origin",
+      });
+      if (!res.ok) throw new Error(`delete failed: ${res.status}`);
+  
+      // トークンローテーション
+      const nat = res.headers.get("access-token");
+      if (nat) localStorage.setItem("access-token", nat);
+      const nclient = res.headers.get("client");
+      if (nclient) localStorage.setItem("client", nclient);
+      const nuid = res.headers.get("uid");
+      if (nuid) localStorage.setItem("uid", nuid);
+      const nexpiry = res.headers.get("expiry");
+      if (nexpiry) localStorage.setItem("expiry", nexpiry);
+      const nt = res.headers.get("token-type");
+      if (nt) localStorage.setItem("token-type", nt);
+    }, id);
+  }
 
 export async function titleIndexes(page: Page, titles: string[]) {
   const idx = await page.$$eval(

--- a/frontend/tests/dnd/guard.children-fixed.spec.ts
+++ b/frontend/tests/dnd/guard.children-fixed.spec.ts
@@ -2,9 +2,17 @@
 import { test, expect } from "@playwright/test";
 import H from "./_helpers";
 
+test.use({ storageState: "tests/.auth/e2e.json" });
+
 test.describe("@dnd 仕様：子はドラッグ不可", () => {
   test("子タスクはハンドルが出ず、順序は変わらない", async ({ page }) => {
     await page.goto("/tasks");
+    // UI 側にトークン読ませる → 初回 /api/tasks の 200 を待つ
+    await page.evaluate(() => window.dispatchEvent(new Event("auth:refresh")));
+    await page
+      .waitForResponse((r) => r.url().includes("/api/tasks") && r.request().method() === "GET" && r.status() === 200, { timeout: 10_000 })
+      .catch(() => {});
+
     const stamp = Date.now();
 
     const p = await H.apiCreateTask(page, { title: `E2E-G-P-${stamp}`, site: "e2e" });

--- a/frontend/tests/dnd/reorder.root.spec.ts
+++ b/frontend/tests/dnd/reorder.root.spec.ts
@@ -1,9 +1,15 @@
 import { test, expect } from "@playwright/test";
 import H from "./_helpers";
 
+test.use({ storageState: "tests/.auth/e2e.json" });
+
 test.describe("@dnd 親の並べ替え（root）", () => {
   test("親タスクを after 仕様で並べ替えできる", async ({ page }) => {
     await page.goto("/tasks");
+    await page.evaluate(() => window.dispatchEvent(new Event("auth:refresh")));
+    await page
+      .waitForResponse((r) => r.url().includes("/api/tasks") && r.request().method() === "GET" && r.status() === 200, { timeout: 10_000 })
+      .catch(() => {});
 
     const stamp = Date.now();
     const p1 = await H.apiCreateTask(page, { title: `E2E-ROOT-P1-${stamp}`, site: "e2e" });
@@ -23,8 +29,7 @@ test.describe("@dnd 親の並べ替え（root）", () => {
 
     await expect.poll(async () => {
       const [j1, j2, j3] = await H.titleIndexes(page, [p1.title, p2.title, p3.title]);
-      // 期待: p1 < p3 < p2
-      return j1 < j3 && j3 < j2;
+      return j1 < j3 && j3 < j2; // 期待: p1 < p3 < p2
     }).toBeTruthy();
 
     await H.apiDeleteTask(page, p1.id);

--- a/frontend/tests/filter-progress-boundary.spec.ts
+++ b/frontend/tests/filter-progress-boundary.spec.ts
@@ -1,0 +1,56 @@
+// tests/filter-progress-boundary.spec.ts（置き換え）
+import { test, expect } from "@playwright/test";
+import { createTaskViaApi, ensureAuthTokens } from "./helpers";
+
+test.use({ storageState: "tests/.auth/e2e.json" });
+
+async function openTasksWithBar(page) {
+  await page.goto("/tasks");
+  await ensureAuthTokens(page);
+  await page.reload();
+  await page.waitForSelector('[data-testid="filter-bar"]', { timeout: 10_000 });
+  await page.waitForLoadState("networkidle");
+}
+
+async function waitForFetch(page, qs: string[]) {
+  await page
+    .waitForResponse(
+      (r) =>
+        r.url().includes("/api/tasks") &&
+        r.request().method() === "GET" &&
+        qs.every((k) => r.url().includes(k)) &&
+        r.status() === 200,
+      { timeout: 10_000 }
+    )
+    .catch(() => {});
+  await page.waitForLoadState("networkidle");
+}
+
+test("境界値: min=max=50 で 50 のみ、解除で全件", async ({ page }) => {
+  await openTasksWithBar(page);
+
+  const site = `E2E-PROG-B-${Date.now()}`;
+  const t40 = await createTaskViaApi(page, { title: "p40", site, parent_id: null, progress: 40 });
+  const t50 = await createTaskViaApi(page, { title: "p50", site, parent_id: null, progress: 50 });
+  const t60 = await createTaskViaApi(page, { title: "p60", site, parent_id: null, progress: 60 });
+
+  const bar = page.getByTestId("filter-bar");
+
+  await bar.getByTestId("filter-site").fill(site);
+  await waitForFetch(page, [encodeURIComponent(`site=${site}`)]);
+
+  await bar.getByTestId("progress-min").fill("50");
+  await bar.getByTestId("progress-max").fill("50");
+  await waitForFetch(page, ["progress_min=50", "progress_max=50"]);
+
+  await expect(page.getByTestId(`task-item-${t50.id}`)).toBeVisible();
+  await expect(page.getByTestId(`task-item-${t40.id}`)).not.toBeVisible();
+  await expect(page.getByTestId(`task-item-${t60.id}`)).not.toBeVisible();
+
+  // リセットで全件復帰
+  await bar.getByTestId("filter-reset").click();
+  await waitForFetch(page, []); // 何も指定しない（/api/tasks の 200 を待つ）
+  await expect(page.getByTestId(`task-item-${t40.id}`)).toBeVisible();
+  await expect(page.getByTestId(`task-item-${t50.id}`)).toBeVisible();
+  await expect(page.getByTestId(`task-item-${t60.id}`)).toBeVisible();
+});

--- a/frontend/tests/filter-progress.spec.ts
+++ b/frontend/tests/filter-progress.spec.ts
@@ -1,0 +1,57 @@
+// tests/filter-progress.spec.ts（置き換え）
+import { test, expect } from "@playwright/test";
+import { createTaskViaApi, ensureAuthTokens } from "./helpers";
+
+test.use({ storageState: "tests/.auth/e2e.json" });
+
+async function openTasksWithBar(page) {
+  await page.goto("/tasks");
+  await ensureAuthTokens(page);
+  await page.reload();
+  await page.waitForSelector('[data-testid="filter-bar"]', { timeout: 10_000 });
+  await page.waitForLoadState("networkidle");
+}
+
+async function waitForFetch(page, qs: string[]) {
+  await page
+    .waitForResponse(
+      (r) =>
+        r.url().includes("/api/tasks") &&
+        r.request().method() === "GET" &&
+        qs.every((k) => r.url().includes(k)) &&
+        r.status() === 200,
+      { timeout: 10_000 }
+    )
+    .catch(() => {});
+  await page.waitForLoadState("networkidle");
+}
+
+test("進捗 20–80 だけ表示（0/100 は除外）", async ({ page }) => {
+  await openTasksWithBar(page);
+
+  const site = `E2E-PROG-${Date.now()}`;
+  const t0   = await createTaskViaApi(page, { title: "p0",   site, parent_id: null, progress: 0 });
+  const t20  = await createTaskViaApi(page, { title: "p20",  site, parent_id: null, progress: 20 });
+  const t50  = await createTaskViaApi(page, { title: "p50",  site, parent_id: null, progress: 50 });
+  const t80  = await createTaskViaApi(page, { title: "p80",  site, parent_id: null, progress: 80 });
+  const t100 = await createTaskViaApi(page, { title: "p100", site, parent_id: null, progress: 100 });
+
+  const bar = page.getByTestId("filter-bar");
+
+  // 現場名で対象だけに絞る → まず site クエリ反映を待つ
+  await bar.getByTestId("filter-site").fill(site);
+  await waitForFetch(page, [encodeURIComponent(`site=${site}`)]);
+
+  // 進捗レンジ
+  await bar.getByTestId("progress-min").fill("20");
+  await bar.getByTestId("progress-max").fill("80");
+  await waitForFetch(page, ["progress_min=20", "progress_max=80"]);
+
+  await expect(page.getByTestId(`task-item-${t20.id}`)).toBeVisible();
+  await expect(page.getByTestId(`task-item-${t50.id}`)).toBeVisible();
+  await expect(page.getByTestId(`task-item-${t80.id}`)).toBeVisible();
+
+  // DOM 残骸対策：非対象は「非表示」を確認
+  await expect(page.getByTestId(`task-item-${t0.id}`)).not.toBeVisible();
+  await expect(page.getByTestId(`task-item-${t100.id}`)).not.toBeVisible();
+});

--- a/frontend/tests/new-parent-box.spec.ts
+++ b/frontend/tests/new-parent-box.spec.ts
@@ -1,13 +1,25 @@
 import { test, expect } from "@playwright/test";
 
+test.use({ storageState: "tests/.auth/e2e.json" });
+
 test("上位タスク作成ボックスで親を作れる", async ({ page }) => {
   await page.goto("/tasks");
+  await page.evaluate(() => window.dispatchEvent(new Event("auth:refresh")));
+  await page
+    .waitForResponse((r) => r.url().includes("/api/tasks") && r.request().method() === "GET" && r.status() === 200, { timeout: 10_000 })
+    .catch(() => {});
 
   const title = `NP-${Date.now()}`;
   await page.getByTestId("new-parent-title").fill(title);
   await page.getByTestId("new-parent-site").fill("E2E-BOX");
-  // 期限は任意入力。空でも可
-  await page.getByTestId("new-parent-submit").click();
+
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes("/api/tasks") && r.request().method() === "POST" && r.status() === 201, { timeout: 10_000 }),
+    page.getByTestId("new-parent-submit").click(),
+  ]);
+
+  await page.reload();
+  await page.waitForLoadState("networkidle");
 
   await expect(page.getByText(title).first()).toBeVisible();
   await expect(page.getByText("上位タスク").first()).toBeVisible(); // バッジ確認


### PR DESCRIPTION
## 概要
タスク一覧のフィルタに **進捗レンジ（min/max）** を追加しました。  
URL クエリと双方向同期し、「すべて解除」で progress_* も含めて初期化されます。  
サーバ側は既存の `by_progress_min` / `by_progress_max` をそのまま利用するため **API の追加はありません**。

## 変更点
- UI
  - `TaskFilterBar` に `progress_min` / `progress_max` 入力を追加（0–100、空=未指定）
  - クエリ同期：`?progress_min=…&progress_max=…`
  - チップに `progress: x–y` を表示
  - 「すべて解除」で progress_* もクリア
- サーバ
  - 変更なし（既存スコープで対応済み）
- テスト
  - `tests/filter-progress.spec.ts`：20–80 のみ表示、0/100 は除外を検証
  - `tests/filter-progress-boundary.spec.ts`：min=max=50 のみ表示、リセットで全件復帰
  - 認証の安定化（storageState / `auth:refresh` / /api/tasks=200 待ち）
  - API ヘルパのトークン付与・ローテーション保存、`credentials: "same-origin"` を徹底

## 動作確認
1. `/tasks` を開く
2. 進捗の **min=20, max=80** に設定
3. 0％と100％のタスクが非表示、20–80％のタスクのみ表示されること
4. 「すべて解除」で progress_* が消え、全件に戻ること
5. URLのクエリに `progress_min` / `progress_max` が反映・復元されること