### PR TITLE
feat(drawer): 詳細ドロワーに基本フィールドを描画（ステータス/進捗/site/期限/子サマリ/監査情報）

### DIFF
--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function ProgressBar({ value, "data-testid": testId }: { value: number; "data-testid"?: string }) {
+  const v = Math.max(0, Math.min(100, Math.round(value)));
+  return (
+    <div className="h-2 w-full rounded bg-gray-200/80" aria-label="進捗バー" data-testid={testId}>
+      <div className="h-2 rounded bg-blue-500" style={{ width: `${v}%` }} />
+    </div>
+  );
+}

--- a/frontend/src/components/StatusPill.tsx
+++ b/frontend/src/components/StatusPill.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import type { Status } from "../type";
+
+const LABEL: Record<Status, string> = {
+  not_started: "未着手",
+  in_progress: "進行中",
+  completed: "完了",
+};
+
+const COLOR: Record<Status, string> = {
+  not_started: "bg-gray-100 text-gray-700",
+  in_progress: "bg-blue-100 text-blue-700",
+  completed: "bg-green-100 text-green-700",
+};
+
+export default function StatusPill({ status }: { status: Status }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] ${COLOR[status]}`}>
+      {LABEL[status]}
+    </span>
+  );
+}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,9 @@
+export const toYmd = (iso: string | null | undefined): string | null => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${d.getFullYear()}-${mm}-${dd}`;
+  };
+  


### PR DESCRIPTION
# 概要
詳細ドロワーの本文を実装。open時の取得データを用いて、基本フィールドを表示します。

# 変更内容
- components: StatusPill/ProgressBar を追加
- utils: date.ts に toYmd を追加
- TaskDrawer: 成功時の本文を正式レイアウトに置き換え（タイトル/ステータス/進捗/サイト/期限/子サマリ/監査情報）
- a11y: aria-labelledby をタスク名の見出しに紐づけ

# 動作確認
- 親タイトル→ドロワー：ローディング→本文が表示される
- 期限は yyyy-mm-dd / 未設定 で表示
- 子サマリの表示（完了x/総数y）がAPIの値と一致
- 閉じる挙動・フォーカス復帰は維持

# 影響範囲/リスク
- 特になし（表示のみの追加）
