### PR TITLE
Feat/api active storage setup

### DIFF
--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -23,7 +23,9 @@ class Task < ApplicationRecord
             allow_nil: true
   # 並び順
   validates :position, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
-
+  
+  has_one_attached :image
+  
   # depth/position は作成時に自動計算・更新時の親変更でも末尾へ
   before_validation :set_depth, on: :create
   before_validation :set_position_at_end, on: :create

--- a/backend/db/migrate/20250905000956_create_active_storage_tables.active_storage.rb
+++ b/backend/db/migrate/20250905000956_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_23_023751) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_05_000956) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -54,6 +82,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_23_023751) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "tasks", "tasks", column: "parent_id"
   add_foreign_key "tasks", "users"
 end

--- a/backend/spec/requests/tasks_children_limit_spec.rb
+++ b/backend/spec/requests/tasks_children_limit_spec.rb
@@ -1,3 +1,4 @@
+# spec/requests/tasks_children_limit_spec.rb
 require "rails_helper"
 
 RSpec.describe "Tasks children limit", type: :request do
@@ -20,24 +21,25 @@ RSpec.describe "Tasks children limit", type: :request do
     expect(JSON.parse(response.body)["errors"].join).to match(/最大4件/)
   end
 
-  it "親付け替え：既に4件いる親へ移動は422、空きのある親へはOK" do
+  it "親またぎ移動は常に422（仕様：親またぎ不可）" do
     a = create(:task, user: user, site: "A")
     b = create(:task, user: user, site: "B")
     4.times { |i| create(:task, user: user, parent: a, title: "A子#{i + 1}") }
     moving = create(:task, user: user, parent: b, title: "移動対象")
 
-    # 満杯の a へ → 422
+    # 満杯の a へ → 422（満杯かどうかに関係なくNG）
     patch "/api/tasks/#{moving.id}",
           params: { task: { parent_id: a.id } }.to_json,
           headers: auth_headers_for(user).merge(json_headers)
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)["errors"].join).to match(/最大4件/)
+    expect(JSON.parse(response.body)["errors"].join).to match(/親をまたぐ移動は不可/)
 
-    # 空きのある c へ → 200
+    # 空きのある c へ → 422（仕様上、親またぎは常にNG）
     c = create(:task, user: user, site: "C")
     patch "/api/tasks/#{moving.id}",
           params: { task: { parent_id: c.id } }.to_json,
           headers: auth_headers_for(user).merge(json_headers)
-    expect(response).to have_http_status(:ok)
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(JSON.parse(response.body)["errors"].join).to match(/親をまたぐ移動は不可/)
   end
 end


### PR DESCRIPTION
# 概要
Active Storage を導入し、開発・テスト環境のストレージ設定を追加。
Task に画像添付用の関連（has_one_attached :image）を1行だけ付与。
このブランチでは API のエンドポイント実装やバリデーションは行わず、土台のみ。

# 変更内容
- Active Storage のマイグレーションを追加し、db:migrate を前提化
- config/storage.yml に local/test を確認・追記（上書きなし）
- development/test 環境で Active Storage サービスを指定
- `app/models/task.rb` に `has_one_attached :image` を追加（既存機能への影響なし）

# 動作確認
- `bin/rails db:migrate` および `RAILS_ENV=test bin/rails db:migrate` が成功すること
- 既存の Task CRUD や認証 API が従来どおり動くこと（画像未使用のため差分なし）
- RSpec が従来どおりパスすること

# 影響範囲 / リスク
- DB に Active Storage 用の3テーブルが追加されるのみ。既存コードの呼び出し側に変更なし。
- 画像添付を実際に使うのは次ブランチ（API実装）から。

# ロールバック
- `rails db:rollback` で本マイグレーションを戻せる
- `Task` の `has_one_attached :image` 1行を削除で元通り

# 補足
- 次ブランチ：`feat/api-image-endpoints`（POST/DELETE・バリデーション・サムネvariant・RSpec）

# 追加: テストの仕様整合
- DnD仕様の最終決定（親またぎ移動は不可）に合わせて、`tasks_children_limit_spec` の期待値を更新。
- これにより、親が満杯/空きありに関わらず、親またぎ移動は 422 とし、エラーメッセージは「親をまたぐ移動は不可です」を期待。
