### PR TITLE
親タスクに画像パネル追加／Drawerはサムネ優先表示（axiosインターセプタ対応）

### DIFF
--- a/frontend/src/features/drawer/ImagePreviewList.tsx
+++ b/frontend/src/features/drawer/ImagePreviewList.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+
+type Props = {
+  /** 原寸URL（リンク先） */
+  url: string;
+  /** alt用タイトル */
+  title: string;
+  /** 省略可：指定時は <img> にこちらを使う（サムネ優先表示） */
+  thumbUrl?: string;
+};
+
+export default function ImagePreview({ url, title, thumbUrl }: Props) {
+  const [loaded, setLoaded] = useState(false);
+  const [err, setErr] = useState<Error | null>(null);
+
+  // エラー時は簡易プレースホルダにフォールバック
+  if (err) {
+    return (
+      <figure className="rounded-md border bg-gray-50">
+        <div className="flex h-44 items-center justify-center text-xs text-gray-500">
+          画像を読み込めませんでした
+        </div>
+        <figcaption className="border-t px-3 py-2 text-[11px] text-gray-600">
+          画像プレビュー（クリックで原寸表示）
+        </figcaption>
+      </figure>
+    );
+  }
+
+  return (
+    <figure className="rounded-md border bg-white">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block"
+        aria-label="画像を新しいタブで開く"
+      >
+        {/* 画像本体（thumb優先） */}
+        <img
+          src={thumbUrl && typeof thumbUrl === "string" ? thumbUrl : url}
+          alt={`${title} の画像`}
+          className={`block h-44 w-full object-cover ${loaded ? "" : "hidden"}`}
+          onLoad={() => setLoaded(true)}
+          onError={() => setErr(new Error("image load failed"))}
+          loading="lazy"
+          decoding="async"
+          referrerPolicy="no-referrer"
+        />
+        {/* ローディング中のプレースホルダ */}
+        {!loaded && (
+          <div className="h-44 w-full animate-pulse bg-gray-200" aria-hidden />
+        )}
+      </a>
+      <figcaption className="border-t px-3 py-2 text-[11px] text-gray-600">
+        画像プレビュー（クリックで原寸表示）
+      </figcaption>
+    </figure>
+  );
+}

--- a/frontend/src/features/drawer/TaskDrawer.tsx
+++ b/frontend/src/features/drawer/TaskDrawer.tsx
@@ -10,7 +10,7 @@ import StatusPill from "../../components/StatusPill";
 import ProgressBar from "../../components/ProgressBar";
 import { toYmd } from "../../utils/date";
 import ChildPreviewList from "./ChildPreviewList";
-import ImagePreview from "./ImagePreview";
+import ImagePreview from "./ImagePreviewList";
 import { useToast } from "../../components/ToastProvider";
 
 const RootPortal: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -87,7 +87,10 @@ export default function TaskDrawer() {
   const prog = Math.max(0, Math.min(100, Math.round(data?.progress_percent ?? 0)));
   const preview = data?.children_preview ?? [];
   const grandkids = typeof data?.grandchildren_count === "number" ? data!.grandchildren_count : 0;
+
+  // 画像関連
   const imageUrl = data?.image_url ?? null;
+  const imageThumbUrl = data?.image_thumb_url ?? null;
 
   return (
     <RootPortal>
@@ -175,10 +178,10 @@ export default function TaskDrawer() {
               {/* 直下の子プレビュー（最大4件）＆孫件数 */}
               <ChildPreviewList items={preview} grandchildrenCount={grandkids} />
 
-              {/* 画像（存在時のみ） */}
+              {/* 画像（存在時のみ / サムネがあればサムネを表示し、クリックで原寸を開く） */}
               {imageUrl && (
                 <div className="mt-4">
-                  <ImagePreview url={imageUrl} title={data.title} />
+                  <ImagePreview url={imageUrl} thumbUrl={imageThumbUrl ?? undefined} title={data.title} />
                 </div>
               )}
 

--- a/frontend/src/features/tasks/image/TaskImagePanel.tsx
+++ b/frontend/src/features/tasks/image/TaskImagePanel.tsx
@@ -1,0 +1,140 @@
+// src/features/tasks/image/TaskImagePanel.tsx
+import { useEffect, useRef, useState } from "react";
+import api from "../../../lib/apiClient";
+
+type Props = { taskId: number };
+type ShowResponse = { image_url: string | null; image_thumb_url: string | null };
+
+const MAX_MB = 5;
+const ACCEPT = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+export default function TaskImagePanel({ taskId }: Props) {
+  const [data, setData] = useState<ShowResponse>({ image_url: null, image_thumb_url: null });
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const fetchShow = async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await api.get(`/tasks/${taskId}`);
+      const json = res.data;
+      setData({ image_url: json.image_url ?? null, image_thumb_url: json.image_thumb_url ?? null });
+    } catch (e: any) {
+      setErr(e?.message || "読み込みに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchShow(); }, [taskId]);
+
+  const onPick = () => fileRef.current?.click();
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setErr(null);
+
+    if (!ACCEPT.includes(f.type)) {
+      setErr("許可形式: jpeg/png/webp/gif");
+      e.target.value = "";
+      return;
+    }
+    if (f.size > MAX_MB * 1024 * 1024) {
+      setErr(`ファイルサイズは${MAX_MB}MB以下にしてください`);
+      e.target.value = "";
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("image", f, f.name);
+      await api.post(`/tasks/${taskId}/image`, fd); // ← ヘッダ指定なし
+      await fetchShow();
+    } catch (e: any) {
+      const msg = e?.response?.data?.errors?.join?.("、") || e?.message || "アップロードに失敗しました";
+      setErr(msg);
+    } finally {
+      setUploading(false);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  };
+
+  const onDelete = async () => {
+    if (!confirm("画像を削除しますか？")) return;
+    setUploading(true);
+    setErr(null);
+    try {
+      await api.delete(`/tasks/${taskId}/image`);
+      await fetchShow();
+    } catch (e: any) {
+      const msg = e?.response?.data?.errors?.join?.("、") || e?.message || "削除に失敗しました";
+      setErr(msg);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const hasImage = !!data.image_url;
+
+  return (
+    <div className="mt-2 rounded-md border p-3 bg-white">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium">画像</h3>
+        <div className="space-x-2">
+          <button
+            type="button"
+            className="rounded bg-gray-900 px-2 py-1 text-xs text-white disabled:opacity-60"
+            onClick={onPick}
+            disabled={uploading || loading}
+            title="画像を選択してアップロード"
+          >
+            {hasImage ? "画像を変更" : "画像を追加"}
+          </button>
+          {hasImage && (
+            <button
+              type="button"
+              className="rounded border px-2 py-1 text-xs disabled:opacity-60"
+              onClick={onDelete}
+              disabled={uploading || loading}
+            >
+              削除
+            </button>
+          )}
+          <input
+            ref={fileRef}
+            type="file"
+            accept={ACCEPT.join(",")}
+            className="hidden"
+            onChange={onFileChange}
+          />
+        </div>
+      </div>
+
+      {err && <div className="mb-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{err}</div>}
+
+      {loading ? (
+        <div className="text-xs text-gray-500">読み込み中…</div>
+      ) : hasImage ? (
+        <div className="flex items-start gap-3">
+          <img
+            src={data.image_thumb_url || data.image_url!}
+            alt="サムネイル"
+            className="h-24 w-24 rounded object-cover ring-1 ring-gray-200"
+          />
+          <a href={data.image_url!} target="_blank" rel="noreferrer" className="text-xs text-blue-700 underline">
+            元画像を開く
+          </a>
+        </div>
+      ) : (
+        <div className="text-xs text-gray-600">画像は未設定です。</div>
+      )}
+
+      <p className="mt-2 text-[11px] text-gray-500">許可形式: jpeg/png/webp/gif、サイズ: {MAX_MB}MB以下</p>
+    </div>
+  );
+}

--- a/frontend/src/features/tasks/inline/InlineTaskRow.tsx
+++ b/frontend/src/features/tasks/inline/InlineTaskRow.tsx
@@ -1,4 +1,3 @@
-// src/features/tasks/inline/inlineTaskRow.tsx
 import { useMemo, useState, useLayoutEffect, type DragEvent, useRef } from "react";
 import type { Task } from "../../../types/task";
 import { useUpdateTask } from "../../tasks/useUpdateTask";
@@ -7,6 +6,7 @@ import { useCreateTask } from "../../tasks/useCreateTask";
 import { MAX_CHILDREN_PER_NODE } from "../../tasks/constraints";
 import { useInlineDnd } from "./dndContext";
 import { useTaskDrawer } from "../../drawer/useTaskDrawer";
+import TaskImagePanel from "../image/TaskImagePanel";
 
 const toDateInputValue = (iso?: string | null) => {
   if (!iso) return "";
@@ -60,6 +60,7 @@ export default function InlineTaskRow({ task, depth }: RowProps) {
 
   const [addingChild, setAddingChild] = useState(false);
   const [childTitle, setChildTitle] = useState("");
+  const [showImagePanel, setShowImagePanel] = useState(false);
 
   const { open: openDrawer } = useTaskDrawer();
   const titleRef = useRef<HTMLSpanElement | null>(null);
@@ -372,6 +373,18 @@ export default function InlineTaskRow({ task, depth }: RowProps) {
               編集
             </button>
 
+            {/* 親のみ：画像パネル */}
+            {isParent && (
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={() => setShowImagePanel((v) => !v)}
+                title="画像の表示・アップロード・削除"
+              >
+                画像
+              </button>
+            )}
+
             <button
               type="button"
               data-testid={`task-add-child-${task.id}`}
@@ -460,6 +473,8 @@ export default function InlineTaskRow({ task, depth }: RowProps) {
       aria-expanded={children.length ? expanded : undefined}
     >
       {Row}
+      {/* 親タスク専用：インライン画像パネル */}
+      {isParent && showImagePanel && <TaskImagePanel taskId={task.id} />}
       {Children}
     </div>
   );

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -6,8 +6,39 @@ const api = axios.create({
   withCredentials: false,
   headers: {
     Accept: "application/json",
+    // ← Content-Type は基本JSONだが、FormDataのときはインターセプタで消す
     "Content-Type": "application/json",
   },
+});
+
+// ---- 認証ヘッダ注入 & multipart調整 ----
+api.interceptors.request.use((config) => {
+  // Devise Token Auth の各ヘッダをlocalStorageから注入
+  const keys = ["access-token", "client", "uid", "token-type", "expiry"] as const;
+  config.headers = config.headers ?? {};
+  for (const k of keys) {
+    const v = localStorage.getItem(k);
+    if (v) (config.headers as any)[k] = v;
+  }
+
+  // data が FormData のときは Content-Type を削除（boundary 自動付与に任せる）
+  if (typeof FormData !== "undefined" && config.data instanceof FormData) {
+    if ((config.headers as any)["Content-Type"]) {
+      delete (config.headers as any)["Content-Type"];
+    }
+  }
+
+  return config;
+});
+
+// ---- トークンのローテーション反映 ----
+api.interceptors.response.use((res) => {
+  const keys = ["access-token", "client", "uid", "token-type", "expiry"] as const;
+  for (const k of keys) {
+    const v = res.headers?.[k];
+    if (v) localStorage.setItem(k, v);
+  }
+  return res;
 });
 
 export default api;


### PR DESCRIPTION
# 概要
- 親タスク行の直下に画像パネルを追加し、画像の表示・アップロード・削除を可能にしました
- Drawerは閲覧専用のまま、`image_thumb_url` があればサムネ優先表示に変更（クリックで原寸）
- フロントの呼び出しは axios(apiClient) に統一。FormData時に `Content-Type` を自動で外し、DTAトークンの注入/更新も自動化

# 変更内容
- lib: `apiClient.ts`
  - リクエスト時に DTA ヘッダ（access-token/client/uid/token-type/expiry）を注入
  - `FormData` 送信時は `Content-Type` を削除（boundary自動付与）
  - レスポンスのDTAヘッダで localStorage をローテーション
- web: `TaskImagePanel.tsx` 新規（/api/tasks/:id/image の POST/DELETE、GET /tasks/:id で再取得）
- ui: `inlineTaskRow.tsx` 親のみ「画像」ボタン→パネル展開
- drawer: `ImagePreviewList.tsx` が `thumbUrl` を受け取り可能に（後方互換）
- drawer: `TaskDrawer.tsx` は `image_thumb_url` があればそちらを表示（原寸リンクは維持）
- （掃除）`dtaHeaders.ts` を削除（インターセプタに統一）

# 動作確認
- 親タスクのみ「画像」ボタンが表示される
- jpeg/png/webp/gif & ≤5MB でアップロード成功、サムネ表示／「元画像を開く」リンクで原寸
- 不正MIME or 5MB超はエラーバナー表示（422）
- Drawerでサムネが表示され、クリックで原寸タブが開く

# 影響範囲・互換性
- 既存の一覧/優先度/Drawer機能は後方互換。Drawerは表示ロジックのみ変更（thumb優先）
- 共通クライアント(`apiClient`)にインターセプタ追加（他のFormData送信でも恩恵あり）