### PR TITLE
画像アップロード〜表示の一連改善：親タスクサムネ・ドロワー画像連携・UI整理（表記「現場名」に統一）

### DIFF
--- a/frontend/src/features/drawer/ImagePreviewList.tsx
+++ b/frontend/src/features/drawer/ImagePreviewList.tsx
@@ -1,19 +1,17 @@
 import React, { useState } from "react";
 
 type Props = {
-  /** 原寸URL（リンク先） */
-  url: string;
-  /** alt用タイトル */
+  url: string;        // 原寸URL
   title: string;
-  /** 省略可：指定時は <img> にこちらを使う（サムネ優先表示） */
-  thumbUrl?: string;
+  thumbUrl?: string;  // 追加: サムネURL（あれば優先）
 };
 
 export default function ImagePreview({ url, title, thumbUrl }: Props) {
   const [loaded, setLoaded] = useState(false);
   const [err, setErr] = useState<Error | null>(null);
 
-  // エラー時は簡易プレースホルダにフォールバック
+  const display = thumbUrl || url;
+
   if (err) {
     return (
       <figure className="rounded-md border bg-gray-50">
@@ -36,9 +34,8 @@ export default function ImagePreview({ url, title, thumbUrl }: Props) {
         className="block"
         aria-label="画像を新しいタブで開く"
       >
-        {/* 画像本体（thumb優先） */}
         <img
-          src={thumbUrl && typeof thumbUrl === "string" ? thumbUrl : url}
+          src={display}
           alt={`${title} の画像`}
           className={`block h-44 w-full object-cover ${loaded ? "" : "hidden"}`}
           onLoad={() => setLoaded(true)}
@@ -47,10 +44,7 @@ export default function ImagePreview({ url, title, thumbUrl }: Props) {
           decoding="async"
           referrerPolicy="no-referrer"
         />
-        {/* ローディング中のプレースホルダ */}
-        {!loaded && (
-          <div className="h-44 w-full animate-pulse bg-gray-200" aria-hidden />
-        )}
+        {!loaded && <div className="h-44 w-full animate-pulse bg-gray-200" aria-hidden />}
       </a>
       <figcaption className="border-t px-3 py-2 text-[11px] text-gray-600">
         画像プレビュー（クリックで原寸表示）

--- a/frontend/src/features/drawer/useTaskDrawer.tsx
+++ b/frontend/src/features/drawer/useTaskDrawer.tsx
@@ -1,8 +1,11 @@
 import React, { createContext, useCallback, useContext, useRef, useState } from "react";
 
+type OpenOpts = { section?: "image" };
+
 type Ctx = {
   openTaskId: number | null;
-  open: (taskId: number, triggerEl?: HTMLElement | null) => void;
+  openSection: "image" | null;
+  open: (taskId: number, triggerEl?: HTMLElement | null, opts?: OpenOpts) => void;
   close: () => void;
 };
 
@@ -10,25 +13,25 @@ const DrawerCtx = createContext<Ctx | null>(null);
 
 export const TaskDrawerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [openTaskId, setOpenTaskId] = useState<number | null>(null);
+  const [openSection, setOpenSection] = useState<"image" | null>(null);
   const lastTriggerRef = useRef<HTMLElement | null>(null);
 
-  const open = useCallback((taskId: number, triggerEl?: HTMLElement | null) => {
+  const open = useCallback((taskId: number, triggerEl?: HTMLElement | null, opts?: OpenOpts) => {
     lastTriggerRef.current = triggerEl ?? null;
+    setOpenSection(opts?.section ?? null);
     setOpenTaskId(taskId);
   }, []);
 
   const close = useCallback(() => {
     setOpenTaskId(null);
-    // フォーカス復帰
+    setOpenSection(null);
     const t = lastTriggerRef.current;
-    if (t && typeof t.focus === "function") {
-      setTimeout(() => t.focus(), 0);
-    }
+    if (t && typeof t.focus === "function") setTimeout(() => t.focus(), 0);
     lastTriggerRef.current = null;
   }, []);
 
   return (
-    <DrawerCtx.Provider value={{ openTaskId, open, close }}>
+    <DrawerCtx.Provider value={{ openTaskId, openSection, open, close }}>
       {children}
     </DrawerCtx.Provider>
   );

--- a/frontend/src/features/tasks/inline/CompactThumb.tsx
+++ b/frontend/src/features/tasks/inline/CompactThumb.tsx
@@ -1,0 +1,48 @@
+import { useTaskDrawer } from "../../drawer/useTaskDrawer";
+import { useTaskDetail } from "../../tasks/useTaskDetail";
+
+type Props = { taskId: number };
+
+export default function CompactThumb({ taskId }: Props) {
+  const { data } = useTaskDetail(taskId); // react-query キャッシュ共有
+  const { open } = useTaskDrawer();
+
+  const imageUrl = data?.image_url ?? null;
+  const thumbUrl = data?.image_thumb_url ?? null;
+  const hasImage = !!imageUrl;
+
+  const onClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    open(taskId, e.currentTarget, { section: "image" });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={hasImage ? "画像を表示" : "画像は未設定"}
+      title={hasImage ? "画像を表示" : "画像は未設定"}
+      draggable={false}
+      onMouseDown={(e) => e.stopPropagation()} // DnD 干渉防止
+      onClick={onClick}
+      className={[
+        // ⬇️ さらに 2 回り拡大: sm=80px, md=112px
+        "inline-flex h-20 w-20 md:h-28 md:w-28 items-center justify-center overflow-hidden",
+        "rounded ring-1 ring-gray-200 bg-white hover:ring-gray-300 shrink-0",
+      ].join(" ")}
+    >
+      {hasImage ? (
+        <img
+          src={thumbUrl || imageUrl!}
+          alt=""
+          className="block h-full w-full object-cover pointer-events-none"
+          draggable={false}
+        />
+      ) : (
+        <span className="text-[20px] md:text-[24px] leading-none text-gray-600 font-semibold">
+          未
+        </span>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/features/tasks/useTaskDetail.ts
+++ b/frontend/src/features/tasks/useTaskDetail.ts
@@ -5,9 +5,9 @@ import type { TaskDetail } from "../../types";
 
 export function useTaskDetail(taskId?: number | null) {
   return useQuery<TaskDetail, unknown>({
-    queryKey: ["task", taskId],
+    queryKey: ["taskDetail", taskId],   // ← 統一
     enabled: !!taskId,
-    retry: false, // 404・5xxで連続リトライしてトースト連打を防ぐ
+    retry: false,
     queryFn: async () => {
       const { data } = await api.get(`/tasks/${taskId}`);
       return data as TaskDetail;


### PR DESCRIPTION
## 背景
- 画像の添付/差し替えの体験を強化し、リスト→詳細ドロワーまで一貫してプレビューできるようにしたい。
- 親タスクだけに軽量サムネを表示して視認性を上げ、クリックで詳細ドロワーの画像位置へジャンプしたい。
- 表記ゆれ（`site:`）を「現場名」に統一したい。
- 行内ボタンの情報設計を見直し、子タスク追加を目立たせつつ全体のバランスを最適化したい。

---

## 変更点

### Backend（参考）
- 画像バリアント生成を **遅延生成** に変更（`.processed` を外して ActiveStorage に任せる）。
- エラーレスポンス整理：
  - 子タスクへの添付は `422 Unprocessable Entity`
  - 不正 MIME は `422`
  - 正常時は `200` で `image_url` / `image_thumb_url` を返却
- 開発環境での ImageMagick 前提を明文化  
  _RSpec: **55 examples, 0 failures**_

### Frontend
- **親タスクのみ** リストにサムネを表示（子には非表示）。  
  - サムネはクリックで **ドロワーを開き、画像セクションへ自動スクロール**  
  - D&D 干渉回避（`draggable={false}` / `stopPropagation()`）
  - サムネサイズを段階的に拡大し、行のタイポグラフィを再調整（親タイトルの文字サイズアップ）
- **ドロワー**に画像プレビューを追加（サムネがあればサムネを使用、クリックで原寸を新規タブ）
- **アップロードパネル**（行の「画像」ボタン）
  - 許可形式: jpeg/png/webp/gif、上限: 5MB
  - 成功後は react-query の詳細クエリも **invalidate** して即時同期
- **ボタン設計**
  - 子タスク追加は **「＋」** のみ＆青で統一（目立たせる）
  - 削除は **赤** で明確化
- **表記統一**
  - `site:` → **「現場名」** に統一（リスト / ドロワー）

---

## 主要ファイル
- Drawer
  - `src/features/drawer/TaskDrawer.tsx`（画像セクションID・画像タブ要求時のスクロール、「現場名」表記）
  - `src/features/drawer/ImagePreviewList.tsx`（サムネ/原寸切替、ローディング/エラープレースホルダ）
  - `src/features/drawer/useTaskDrawer.tsx`（`open(taskId, triggerEl, { section: "image" })` 対応）
- Inline list
  - `src/features/tasks/inline/CompactThumb.tsx`（親専用サムネ、クリックでドロワー画像へ）
  - `src/features/tasks/inline/inlineTaskRow.tsx`（サムネ配置、親タイトルサイズ調整、ボタン設計刷新、「現場名」表記）
- Upload panel
  - `src/features/tasks/image/TaskImagePanel.tsx`（アップロード/削除、成功後の invalidate、サムネ表示）
- Data fetch
  - `src/features/tasks/useTaskDetail.ts`（`image_url` / `image_thumb_url` を共有）

---

## 動作確認
1. 親タスク行にサムネが表示される（子には非表示）。  
2. サムネをクリック → **詳細ドロワーが開き、画像プレビュー位置まで自動スクロール**。  
3. 行の「画像」から 5MB 以下・許可形式の画像をアップロード。  
   - 成功後、**リストのサムネ／ドロワーのプレビューが更新**される。  
4. 不正MIME/超過サイズでエラーメッセージ表示。  
5. リスト/ドロワーの表記が **「現場名」** になっている。  
6. 子タスク追加は **青い「＋」**、削除は **赤**。

---

## 影響範囲
- 既存 API との後方互換は維持（`image_thumb_url` が存在すれば活用）。
- DB 変更なし。

## 備考
- ローカルでの画像処理に ImageMagick が必要です。
- 追加で `apiClient` に認証ヘッダ Interceptor を入れる場合は別PRで対応予定。
