### PR TITLE
feat(auth): RequireAuth を実装し未ログイン時に /login へ誘導（auth:from 保存）

### DIFF
--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -7,15 +7,12 @@ export default function RequireAuth() {
   const loc = useLocation();
 
   if (!authed) {
-    // 復帰用の from をセッションに保存（AuthProvider 側でも保存するが念のため）
     try {
       const p = loc.pathname + loc.search + loc.hash;
-      if (p.startsWith("/") && !p.startsWith("//")) {
+      if (p.startsWith("/") && !p.startsWith("//") && p !== "/login") {
         sessionStorage.setItem("auth:from", p);
       }
-    } catch {
-      /* ignore */
-    }
+    } catch { /* ignore */ }
     return <Navigate to="/login" replace />;
   }
   return <Outlet />;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,80 +1,228 @@
 // src/pages/Login.tsx
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import useAuth from "../providers/useAuth";
 
-export default function Login() {
-  const { signIn, authed } = useAuth();
-  const nav = useNavigate();
-  const [email, setEmail] = useState("dev@example.com");
-  const [password, setPassword] = useState("password");
-  const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
+type FieldErr = string | null;
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+function takeAuthFrom(): string | null {
+  try {
+    const v = sessionStorage.getItem("auth:from");
+    if (v) sessionStorage.removeItem("auth:from");
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+export default function Login() {
+  const { authed, signIn } = useAuth();
+  const nav = useNavigate();
+
+  const [email, setEmail] = useState("");
+  const [pw, setPw] = useState("");
+  const [showPw, setShowPw] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [errTop, setErrTop] = useState<string | null>(null);
+  const [errEmail, setErrEmail] = useState<FieldErr>(null);
+  const [errPw, setErrPw] = useState<FieldErr>(null);
+
+  // 期限切れ通知
   useEffect(() => {
-    // 期限切れ通知があれば一度だけ表示
-    const expired = sessionStorage.getItem("auth:expired");
-    if (expired) {
-      setError("ログインの有効期限が切れました。再ログインしてください。");
-      sessionStorage.removeItem("auth:expired");
-    }
+    try {
+      if (sessionStorage.getItem("auth:expired") === "1") {
+        setErrTop("セッションの有効期限が切れました。もう一度ログインしてください。");
+        sessionStorage.removeItem("auth:expired");
+      }
+    } catch { /* ignore */ }
   }, []);
 
-  // ★ テストが localStorage にトークンを注入したケースを拾って自動遷移
+  // 既ログインなら /tasks
   useEffect(() => {
-    if (!authed) return;
-    const from = sessionStorage.getItem("auth:from") || "/tasks";
-    sessionStorage.removeItem("auth:from");
-    nav(from, { replace: true });
+    if (authed) nav("/tasks", { replace: true });
   }, [authed, nav]);
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const emailInvalid = useMemo(() => {
+    if (email.trim() === "") return "メールアドレスを入力してください。";
+    if (!emailRe.test(email)) return "メールアドレスの形式が正しくありません。";
+    return null;
+  }, [email]);
+
+  const pwInvalid = useMemo(() => {
+    if (pw.trim() === "") return "パスワードを入力してください。";
+    return null;
+  }, [pw]);
+
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setBusy(true);
-    setError(null);
+    setErrTop(null);
+
+    const eErr = emailInvalid;
+    const pErr = pwInvalid;
+    setErrEmail(eErr);
+    setErrPw(pErr);
+    if (eErr || pErr) return;
+
+    setSubmitting(true);
     try {
-      await signIn(email, password);
-      const from = sessionStorage.getItem("auth:from") || "/tasks";
-      sessionStorage.removeItem("auth:from");
-      nav(from, { replace: true });
+      await signIn(email.trim(), pw);
+      const dest = takeAuthFrom() || "/tasks";
+      nav(dest, { replace: true });
     } catch (err: any) {
-      setError(err?.response?.data?.errors?.[0] ?? "ログインに失敗しました。");
+      const msg =
+        err?.response?.data?.errors?.[0] ??
+        err?.message ??
+        "ログインに失敗しました。メールアドレスまたはパスワードをご確認ください。";
+      setErrTop(String(msg));
     } finally {
-      setBusy(false);
+      setSubmitting(false);
     }
-  };
+  }
+
+  async function handleDemo() {
+    setErrTop(null);
+    const demoEmail = import.meta.env.VITE_DEMO_EMAIL as string | undefined;
+    const demoPass  = import.meta.env.VITE_DEMO_PASS  as string | undefined;
+
+    if (!demoEmail || !demoPass) {
+      setErrTop("デモユーザーが未設定です（VITE_DEMO_EMAIL / VITE_DEMO_PASS）。");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await signIn(demoEmail, demoPass);
+      const dest = takeAuthFrom() || "/tasks";
+      nav(dest, { replace: true });
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.errors?.[0] ??
+        err?.message ??
+        "デモログインに失敗しました。しばらくしてからお試しください。";
+      setErrTop(String(msg));
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   return (
-    <div className="mx-auto mt-24 max-w-sm rounded-lg border p-6 shadow-sm">
-      <h1 className="mb-4 text-lg font-semibold">ログイン</h1>
-      {error && (
-        <div className="mb-3 rounded bg-red-50 p-2 text-sm text-red-700">
-          {error}
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white shadow rounded-2xl p-6">
+          {/* タイトル／説明 */}
+          <h1 className="text-2xl font-bold text-gray-900 text-center">Genba Tasks</h1>
+          <p className="text-sm text-gray-600 text-center mt-1">現場タスクを“見える化”</p>
+
+          {/* エラーバナー */}
+          {errTop && (
+            <div
+              role="alert"
+              className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              data-testid="login-error-banner"
+            >
+              {errTop}
+            </div>
+          )}
+
+          {/* フォーム */}
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+            {/* Email */}
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                className={`mt-1 block w-full rounded-md border px-3 py-2 text-sm outline-none
+                  ${errEmail ? "border-red-300 focus:ring-red-200" : "border-gray-300 focus:ring-blue-200"}`}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                aria-invalid={!!errEmail}
+                aria-describedby={errEmail ? "email-error" : undefined}
+                disabled={submitting}
+                required
+                autoFocus
+              />
+              {errEmail && (
+                <p id="email-error" className="mt-1 text-xs text-red-600">
+                  {errEmail}
+                </p>
+              )}
+            </div>
+
+            {/* Password + 表示切替 */}
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                パスワード
+              </label>
+              <div className="mt-1 relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPw ? "text" : "password"}
+                  autoComplete="current-password"
+                  className={`block w-full rounded-md border px-3 py-2 pr-20 text-sm outline-none
+                    ${errPw ? "border-red-300 focus:ring-red-200" : "border-gray-300 focus:ring-blue-200"}`}
+                  value={pw}
+                  onChange={(e) => setPw(e.target.value)}
+                  aria-invalid={!!errPw}
+                  aria-describedby={errPw ? "password-error" : undefined}
+                  disabled={submitting}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPw((v) => !v)}
+                  className="absolute inset-y-0 right-2 my-auto text-xs px-2 py-1 rounded border border-gray-300 bg-white hover:bg-gray-50"
+                  aria-pressed={showPw}
+                >
+                  {showPw ? "隠す" : "表示"}
+                </button>
+              </div>
+              {errPw && (
+                <p id="password-error" className="mt-1 text-xs text-red-600">
+                  {errPw}
+                </p>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="space-y-2 pt-2">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-60"
+              >
+                {submitting && (
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" strokeWidth="4" opacity="0.25" />
+                    <path d="M22 12a10 10 0 0 1-10 10" fill="none" stroke="currentColor" strokeWidth="4" />
+                  </svg>
+                )}
+                ログイン
+              </button>
+
+              <button
+                type="button"
+                onClick={handleDemo}
+                disabled={submitting}
+                className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+                data-testid="login-demo-button"
+              >
+                デモで試す
+              </button>
+            </div>
+          </form>
         </div>
-      )}
-      <form onSubmit={onSubmit} className="space-y-3">
-        <input
-          className="w-full rounded border p-2"
-          type="email"
-          placeholder="メールアドレス"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          autoFocus
-        />
-        <input
-          className="w-full rounded border p-2"
-          type="password"
-          placeholder="パスワード"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button
-          className="w-full rounded bg-gray-900 px-3 py-2 text-white disabled:opacity-60"
-          disabled={busy}
-        >
-          ログイン
-        </button>
-      </form>
+
+        <p className="mt-3 text-center text-xs text-gray-500">
+          このページは保護されています。未ログインの場合はログインが必要です。
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
概要
- ログインUIとルートガードを受け入れ基準どおり実装。
- 未ログインの遷移は /login へ、成功時は auth:from に復帰。

変更内容
- src/components/RequireAuth.tsx: /login 以外の現在URLを auth:from に保存して誘導
- src/pages/Login.tsx: タイトル/説明、フィールド下バリデーション、role="alert" バナー、PW表示切替、送信中スピナー、デモログインボタン

動作確認
- 未ログインで /tasks → /login（auth:from=/tasks が保存）
- 入力未完や形式不正で各フィールド下にエラー表示
- 認証失敗で上部に role="alert" の赤バナー
- 成功時に auth:from（なければ /tasks）へ復帰
- 「デモで試す」→ VITE_DEMO_EMAIL/PASS 設定時に正常ログイン

影響範囲/リスク
- 認証導線の中心。AuthContext/axios interceptor に依存。
