### PR TITLE
feat(auth): デモログインを追加（トークン管理をAuthContextに統一）

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,9 +1,10 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# db/seeds.rb
+demo_email = ENV.fetch("DEMO_EMAIL", "demo@example.com")
+demo_pass  = ENV.fetch("DEMO_PASS",  "demopassword")
+
+User.find_or_create_by!(email: demo_email) do |u|
+  u.password = demo_pass
+  u.password_confirmation = demo_pass
+  u.name = "Demo"
+end
+puts "[seed] demo user: #{demo_email}/#{demo_pass}"

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -6,39 +6,20 @@ const api = axios.create({
   withCredentials: false,
   headers: {
     Accept: "application/json",
-    // ← Content-Type は基本JSONだが、FormDataのときはインターセプタで消す
     "Content-Type": "application/json",
   },
 });
 
-// ---- 認証ヘッダ注入 & multipart調整 ----
+// ← トークン注入/保存は AuthContext 側でやる
+//    ここでは FormData のときだけ Content-Type を外す
 api.interceptors.request.use((config) => {
-  // Devise Token Auth の各ヘッダをlocalStorageから注入
-  const keys = ["access-token", "client", "uid", "token-type", "expiry"] as const;
-  config.headers = config.headers ?? {};
-  for (const k of keys) {
-    const v = localStorage.getItem(k);
-    if (v) (config.headers as any)[k] = v;
-  }
-
-  // data が FormData のときは Content-Type を削除（boundary 自動付与に任せる）
   if (typeof FormData !== "undefined" && config.data instanceof FormData) {
-    if ((config.headers as any)["Content-Type"]) {
+    if ((config.headers as any)?.["Content-Type"]) {
       delete (config.headers as any)["Content-Type"];
     }
   }
-
   return config;
 });
 
-// ---- トークンのローテーション反映 ----
-api.interceptors.response.use((res) => {
-  const keys = ["access-token", "client", "uid", "token-type", "expiry"] as const;
-  for (const k of keys) {
-    const v = res.headers?.[k];
-    if (v) localStorage.setItem(k, v);
-  }
-  return res;
-});
-
+// レスポンス側でのトークン保存は **削除**
 export default api;


### PR DESCRIPTION
## 概要
- ログイン画面に「デモで試す」を追加。Vite 環境変数の資格情報で即ログイン可能。
- トークンの読み書きを AuthContext 側に統一し、apiClient のレスポンス上書きによる競合を解消。

## 変更点
- Login.tsx: デモボタン実装、未設定時は role="alert"、送信中は disabled+スピナー
- .env.example / vite-env.d.ts: VITE_DEMO_EMAIL / VITE_DEMO_PASS を追加
- apiClient.ts: レスポンスでの localStorage 上書きを削除（FormData の Content-Type 調整のみ残す）
- README: デモログインの設定手順＆トラブルシュートを追記
- （任意）デモログイン時に `sessionStorage:auth:demo=1` をセット

## 動作確認
1. backend に `demo@example.com / demopassword` を作成（seeds でも可）
2. frontend/.env.local に下記を設定 → dev 再起動
   - VITE_DEMO_EMAIL=demo@example.com
   - VITE_DEMO_PASS=demopassword
3. /login → 「デモで試す」
4. /tasks へ遷移、ヘッダーに「ログアウト」表示
5. DevTools Network:
   - `POST /api/auth/sign_in` の Response Headers に `access-token, client, uid, token-type, expiry`
   - 直後の `GET /api/me` の Request Headers に同値＋`Authorization: Bearer ...`、Status=200

## リスク/影響範囲
- 認証周りのみ。apiClient のトークン保存撤去により並列リクエスト時の古いトークン上書きが解消。
- 既存の通常ログインフローは維持。

## ロールバック
- このPRを revert

## チェックリスト
- [ ] `.env.example` 追記
- [ ] 本番環境にも VITE_DEMO_* を登録予定
- [ ] Network で `/api/auth_sign_in → /api/me` のヘッダが期待どおり
