### PR TITLE
feat(ui): デモ環境バッジ＋注意書きを追加（Loginでauth:demo管理）

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,12 +1,31 @@
+// src/components/Header.tsx
 import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import useAuth from "../providers/useAuth";
+import { useEffect, useState } from "react"; // ★ 追加
 
-const HEADER_H = "h-14"; // 3.5rem
+const HEADER_H = "h-14";
 
 export default function Header() {
   const qc = useQueryClient();
   const { authed, uid, name, signOut } = useAuth();
+
+  // ★ デモフラグ監視
+  const [isDemo, setIsDemo] = useState(false);
+  useEffect(() => {
+    const read = () => {
+      try { setIsDemo(sessionStorage.getItem("auth:demo") === "1"); } catch {}
+    };
+    read();
+    window.addEventListener("auth:refresh", read);
+    window.addEventListener("focus", read);
+    window.addEventListener("storage", read); // 別タブ対策
+    return () => {
+      window.removeEventListener("auth:refresh", read);
+      window.removeEventListener("focus", read);
+      window.removeEventListener("storage", read);
+    };
+  }, []);
 
   const handleLogout = async () => {
     qc.clear();
@@ -16,30 +35,26 @@ export default function Header() {
   const display = (name?.trim()) || (uid ? String(uid).split("@")[0] : "");
 
   return (
-    <header
-  className={`fixed inset-x-0 top-0 z-50 bg-blue-600 text-white ${HEADER_H}
-  border-b border-white/10
-  shadow-[0_10px_30px_-6px_rgba(0,0,0,0.35)]`}
->
-      {/* 左寄せ：max-wを使わずpxのみ */}
+    <header className={`fixed inset-x-0 top-0 z-50 bg-blue-600 text-white ${HEADER_H}
+      border-b border-white/10 shadow-[0_10px_30px_-6px_rgba(0,0,0,0.35)]`}>
       <div className="flex h-full items-center justify-between px-4">
-        <Link
-          to="/"
-          className="text-white font-semibold tracking-wide drop-shadow text-lg md:text-xl"
-          title="ホーム"
-        >
+        <Link to="/" className="text-white font-semibold tracking-wide drop-shadow text-lg md:text-xl" title="ホーム">
           Genba Tasks
         </Link>
 
         <div className="flex items-center gap-3 text-sm">
+          {isDemo && (
+            <span
+              className="rounded bg-white/20 px-2 py-0.5 text-[11px] font-medium tracking-wide"
+              title="これはデモ環境です"
+              data-testid="badge-demo"
+            >
+              デモ環境
+            </span>
+          )}
           {authed ? (
             <>
-              <Link
-                to="/account"
-                className="opacity-90 hover:underline underline-offset-2"
-                data-testid="header-user"
-                title="アカウント"
-              >
+              <Link to="/account" className="opacity-90 hover:underline underline-offset-2" data-testid="header-user" title="アカウント">
                 {display} さん
               </Link>
               <button
@@ -52,9 +67,7 @@ export default function Header() {
               </button>
             </>
           ) : (
-            <Link to="/login" className="rounded px-3 py-1 bg-white/10 hover:bg-white/20">
-              ログイン
-            </Link>
+            <Link to="/login" className="rounded px-3 py-1 bg-white/10 hover:bg-white/20">ログイン</Link>
           )}
         </div>
       </div>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,4 +1,3 @@
-// src/pages/Login.tsx
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import useAuth from "../providers/useAuth";
@@ -68,6 +67,13 @@ export default function Login() {
     setSubmitting(true);
     try {
       await signIn(email.trim(), pw);
+
+      // ★ 通常ログインはデモフラグを解除
+      try {
+        sessionStorage.removeItem("auth:demo");
+        window.dispatchEvent(new Event("auth:refresh"));
+      } catch { /* ignore */ }
+
       const dest = takeAuthFrom() || "/tasks";
       nav(dest, { replace: true });
     } catch (err: any) {
@@ -93,6 +99,13 @@ export default function Login() {
     setSubmitting(true);
     try {
       await signIn(demoEmail, demoPass);
+
+      // ★ デモログインフラグを立てる
+      try {
+        sessionStorage.setItem("auth:demo", "1");
+        window.dispatchEvent(new Event("auth:refresh"));
+      } catch { /* ignore */ }
+
       const dest = takeAuthFrom() || "/tasks";
       nav(dest, { replace: true });
     } catch (err: any) {

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import PriorityTasksPanel from "../features/priority/PriorityTasksPanel";
 import { useFilteredTasks } from "../features/tasks/useTasks";
@@ -16,6 +16,21 @@ import { InlineDndProvider } from "../features/tasks/inline/dndContext";
 const TaskList: PageComponent = () => {
   const { authed } = useAuth();
   usePriorityTasks(authed);
+
+  // デモフラグ
+  const [isDemo, setIsDemo] = useState(false);
+  useEffect(() => {
+    const read = () => {
+      try { setIsDemo(sessionStorage.getItem("auth:demo") === "1"); } catch { /* ignore */ }
+    };
+    read();
+    window.addEventListener("auth:refresh", read);
+    window.addEventListener("focus", read);
+    return () => {
+      window.removeEventListener("auth:refresh", read);
+      window.removeEventListener("focus", read);
+    };
+  }, []);
 
   const [sp] = useSearchParams();
   const rawFilters = parseTaskFilters(sp);
@@ -42,6 +57,17 @@ const TaskList: PageComponent = () => {
   return (
     <InlineDndProvider>
       <div className="max-w-6xl mx-auto p-4" data-testid="task-list-root">
+        {/* ★ いちばん上に注意書き */}
+        {isDemo && (
+          <div
+            className="mb-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+            role="note"
+            data-testid="demo-notice"
+          >
+            これは<strong>デモ環境</strong>です。データは定期的に初期化される場合があります。個人情報の入力は避けてください。
+          </div>
+        )}
+
         {/* H1は非表示。右肩要約は TaskFilterBar に渡す */}
         <TaskFilterBar summary={`全 ${tasksFlat.length} 件・${orderLabel}/${dirLabel}`} />
 


### PR DESCRIPTION
## 目的
デモログインであることを明示し、誤入力を防止する。

## 変更点
- Login.tsx
  - デモ成功時に `sessionStorage:auth:demo=1` をセット
  - 通常ログイン成功時は `auth:demo` を削除
  - どちらも `window.dispatchEvent(new Event("auth:refresh"))` でUIへ反映
- Header.tsx
  - `auth:demo` を監視して右上に **「デモ環境」** バッジ表示
  - 監視イベント: `auth:refresh` / `focus` / `storage`
  - `data-testid="badge-demo"`
- TaskList.tsx
  - ページ**最上部**に薄い注意書きを追加（位置をFilterバーの上へ移動）
  - `role="note"`, `data-testid="demo-notice"`

## 動作確認
1. `/login` → **デモで試す**
   - `/tasks` へ遷移
   - ヘッダー右上に **デモ環境** バッジ
   - リスト最上部に注意書き
2. 通常ログイン
   - バッジ・注意書きが非表示になる
3. 別タブ/フォーカス復帰でも表示状態が同期されること

## 影響範囲 / リスク
- UIのみ。既存API呼び出しの変更なし
- セッションストレージの軽微な利用追加

## テスト観点
- `data-testid="badge-demo"` / `"demo-notice"` の存在確認
- 通常ログインで両方が消えること
