### PR TITLE
chore: Docker開発環境の整備（api/db/front）＋ frontend ローカル env 除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# --- frontend local envs (do not commit secrets) ---
+/frontend/.env*.local
+/frontend/.env.local
+/frontend/.env.development.local
+# keep examples
+!/frontend/.env.example

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,24 @@
+ARG RUBY_VERSION=3.2.3
+FROM ruby:${RUBY_VERSION}-slim AS base
+
+ENV LANG=C.UTF-8 \
+    TZ=Asia/Tokyo \
+    BUNDLE_JOBS=4 \
+    BUNDLE_RETRY=3 \
+    BUNDLE_PATH=/usr/local/bundle
+
+WORKDIR /rails
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates git build-essential pkg-config \
+    default-libmysqlclient-dev default-mysql-client libssl-dev tzdata \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN gem install bundler -N
+
+# 依存だけ先に解決してキャッシュを効かせる
+COPY Gemfile Gemfile.lock ./
+RUN bundle config set force_ruby_platform true \
+ && bundle install
+
+EXPOSE 3000

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -171,6 +172,7 @@ GEM
     marcel (1.0.4)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
     net-imap (0.5.9)
@@ -188,6 +190,9 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
+    nokogiri (1.18.9)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.9-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.9-aarch64-linux-musl)
@@ -347,6 +352,8 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    sqlite3 (2.7.3)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (2.7.3-aarch64-linux-gnu)
     sqlite3 (2.7.3-aarch64-linux-musl)
     sqlite3 (2.7.3-arm-linux-gnu)
@@ -393,6 +400,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
+  ruby
   x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu

--- a/backend/bin/compose-entrypoint.sh
+++ b/backend/bin/compose-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Waiting for MySQL at ${DB_HOST:-db}..."
+until mysqladmin ping -h"${DB_HOST:-db}" -u"${DB_USERNAME:-app}" -p"${DB_PASSWORD:-secret}" --silent; do
+  sleep 1
+done
+echo "MySQL is up."
+
+bundle exec rails db:prepare || true
+exec bundle exec rails s -p 3000 -b 0.0.0.0

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,11 +1,27 @@
-# config/initializers/cors.rb
+# frozen_string_literal: true
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:5173', 'http://127.0.0.1:5173'
+    # フロントエンドが動くオリジンを列挙（開発＋本番）
+    allowed = [
+      'http://localhost:5173',
+      'http://127.0.0.1:5173',
+      'https://genba-tasks.com',
+      'https://www.genba-tasks.com'
+    ]
+
+    # CloudFront のディストリビューション ドメインを環境変数で追加したい場合（任意）
+    # 例) CLOUDFRONT_FRONTEND_ORIGIN=https://dxxxxxxx.cloudfront.net
+    cf = ENV['CLOUDFRONT_FRONTEND_ORIGIN']
+    allowed << cf if cf && !cf.empty?
+
+    # 必要なら CloudFront サブドメインの正規表現許可（credentials: true でもOK）
+    origins(*allowed, %r{\Ahttps://[a-z0-9-]+\.cloudfront\.net\z})
+
     resource '*',
-      headers: :any,
-      expose: %w[access-token client uid expiry token-type Authorization x-auth-start],  # ← カンマ大事
-      methods: %i[get post put patch delete options head],
-      credentials: true
+             headers: :any,
+             expose: %w[access-token client uid expiry token-type Authorization x-auth-start],
+             methods: %i[get post put patch delete options head],
+             credentials: true
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+
+services:
+  db:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_DATABASE: app_development
+      MYSQL_USER: app
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: root
+      TZ: Asia/Tokyo
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev        # ← dev用Dockerfileを明示
+    environment:
+      RAILS_ENV: development
+      DB_HOST: db
+      DB_NAME: app_development
+      DB_USERNAME: app
+      DB_PASSWORD: secret
+      TZ: Asia/Tokyo
+      RAILS_LOG_TO_STDOUT: "1"
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./backend:/rails
+      - bundle-cache:/usr/local/bundle
+    command: ["bash", "-lc", "./bin/compose-entrypoint.sh"]
+
+  front:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    environment:
+      VITE_API_BASE_URL: http://localhost:3000
+      VITE_DEMO_EMAIL: demo@example.com
+      VITE_DEMO_PASS: password
+      TZ: Asia/Tokyo
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: ["sh","-lc","pnpm config set store-dir /root/.local/share/pnpm/store --global && pnpm install --no-frozen-lockfile && pnpm dev --host 0.0.0.0"]
+
+
+
+volumes:
+  db-data:
+  bundle-cache:
+

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Example for local development (copy to .env.development.local and fill)
+VITE_API_BASE_URL=http://localhost:3000
+VITE_DEMO_EMAIL=
+VITE_DEMO_PASS=

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+ENV TZ=Asia/Tokyo
+WORKDIR /app
+RUN corepack enable
+RUN corepack prepare pnpm@latest --activate && pnpm config set store-dir /root/.local/share/pnpm/store --global
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install
+COPY . .
+EXPOSE 5173
+CMD ["pnpm","dev","--host","0.0.0.0"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,9 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@tanstack/react-query": "^5.84.1",
     "axios": "^1.11.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,19 +10,22 @@ importers:
     dependencies:
       '@hello-pangea/dnd':
         specifier: ^18.0.1
-        version: 18.0.1(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 18.0.1(@types/react@19.1.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.84.1
-        version: 5.85.5(react@19.1.1)
+        version: 5.85.5(react@18.3.1)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
       react:
-        specifier: ^19.1.0
-        version: 19.1.1
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.1.0
-        version: 19.1.1(react@19.1.1)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6
+        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.30.1
@@ -541,6 +544,10 @@ packages:
     resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1473,6 +1480,10 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1692,10 +1703,10 @@ packages:
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
 
-  react-dom@19.1.1:
-    resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: ^19.1.1
+      react: ^18.3.1
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -1713,8 +1724,21 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.1.1:
-    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+  react-router-dom@6.30.1:
+    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -1768,8 +1792,8 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
-  scheduler@0.26.0:
-    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2310,14 +2334,14 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@hello-pangea/dnd@18.0.1(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@hello-pangea/dnd@18.0.1(@types/react@19.1.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.3
       css-box-model: 1.2.1
       raf-schd: 4.0.3
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      react-redux: 9.2.0(@types/react@19.1.11)(react@19.1.1)(redux@5.0.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-redux: 9.2.0(@types/react@19.1.11)(react@18.3.1)(redux@5.0.1)
       redux: 5.0.1
     transitivePeerDependencies:
       - '@types/react'
@@ -2452,6 +2476,8 @@ snapshots:
     dependencies:
       playwright: 1.55.0
 
+  '@remix-run/router@1.23.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.48.1':
@@ -2516,10 +2542,10 @@ snapshots:
 
   '@tanstack/query-core@5.85.5': {}
 
-  '@tanstack/react-query@5.85.5(react@19.1.1)':
+  '@tanstack/react-query@5.85.5(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.85.5
-      react: 19.1.1
+      react: 18.3.1
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3500,6 +3526,10 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -3687,23 +3717,38 @@ snapshots:
 
   raf-schd@4.0.3: {}
 
-  react-dom@19.1.1(react@19.1.1):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
-      react: 19.1.1
-      scheduler: 0.26.0
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
-  react-redux@9.2.0(@types/react@19.1.11)(react@19.1.1)(redux@5.0.1):
+  react-redux@9.2.0(@types/react@19.1.11)(react@18.3.1)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
-      react: 19.1.1
-      use-sync-external-store: 1.5.0(react@19.1.1)
+      react: 18.3.1
+      use-sync-external-store: 1.5.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.1.11
       redux: 5.0.1
 
   react-refresh@0.17.0: {}
 
-  react@19.1.1: {}
+  react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.1(react@18.3.1)
+
+  react-router@6.30.1(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   read-cache@1.0.0:
     dependencies:
@@ -3794,7 +3839,9 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  scheduler@0.26.0: {}
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   semver@6.3.1: {}
 
@@ -4086,9 +4133,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-sync-external-store@1.5.0(react@19.1.1):
+  use-sync-external-store@1.5.0(react@18.3.1):
     dependencies:
-      react: 19.1.1
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,8 +1,14 @@
 // src/lib/apiClient.ts
-import axios from "axios";
+import axios, { AxiosHeaders, isCancel } from "axios";
+
+// 既存ロジックを尊重して base を作る（VITE_API_BASE_URL があれば /api を付ける）
+const base =
+  import.meta.env.VITE_API_BASE_URL
+    ? `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "")}/api`
+    : "/api";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || "/api",
+  baseURL: base,
   withCredentials: false,
   headers: {
     Accept: "application/json",
@@ -10,16 +16,116 @@ const api = axios.create({
   },
 });
 
-// ← トークン注入/保存は AuthContext 側でやる
-//    ここでは FormData のときだけ Content-Type を外す
+// ★ ここを追加：毎回 localStorage からヘッダを差し込む
 api.interceptors.request.use((config) => {
+  // FormData のときは Content-Type を外す（既存の処理）
   if (typeof FormData !== "undefined" && config.data instanceof FormData) {
     if ((config.headers as any)?.["Content-Type"]) {
       delete (config.headers as any)["Content-Type"];
     }
   }
+
+  try {
+    const at     = localStorage.getItem("access-token");
+    const client = localStorage.getItem("client");
+    const uid    = localStorage.getItem("uid");
+    const type   = localStorage.getItem("token-type") || "Bearer";
+
+    if (at && client && uid) {
+      (config.headers as any)["access-token"] = at;
+      (config.headers as any)["client"]       = client;
+      (config.headers as any)["uid"]          = uid;
+      (config.headers as any)["token-type"]   = type;
+      (config.headers as any)["Authorization"] = `${type} ${at}`;
+    }
+  } catch {
+    /* ignore */
+  }
+
   return config;
 });
 
-// レスポンス側でのトークン保存は **削除**
+
+// 未ログインでも許可するAPI（認証系だけ）
+const AUTH_WHITELIST = [/^\/auth\//, /^\/omniauth\//, /^\/healthz?$/];
+
+// 小物ヘルパ
+function getHeader(h: unknown, key: string): string | undefined {
+  if (h instanceof AxiosHeaders) {
+    const v = h.get(key);
+    return typeof v === "string" ? v : undefined;
+  }
+  const rec = h as Record<string, unknown> | undefined;
+  const v = rec?.[key] ?? rec?.[key.toLowerCase()];
+  return typeof v === "string" ? v : undefined;
+}
+
+// ★ リクエスト前フック
+api.interceptors.request.use((config) => {
+  const headers = AxiosHeaders.from(config.headers);
+
+  // 絶対URL化して path を取り、/api の有無に影響されないよう判定
+  const urlObj = new URL(config.url!, config.baseURL || window.location.origin);
+  // 例: /api/tasks -> /tasks に正規化
+  const path = urlObj.pathname.replace(/^\/api(\/|$)/, "/");
+
+  const at = localStorage.getItem("access-token");
+  const client = localStorage.getItem("client");
+  const uid = localStorage.getItem("uid");
+  const tokenType = localStorage.getItem("token-type") || "Bearer";
+  const authed = !!(at && client && uid);
+  const isWhitelisted = AUTH_WHITELIST.some((re) => re.test(path));
+
+  // 未ログインで、認証系以外のAPIはブロック（401の嵐防止）
+  if (!authed && !isWhitelisted) {
+    return Promise.reject(new axios.Cancel("unauthenticated: blocked by apiClient"));
+  }
+
+  // 送るなら token を必ず付ける（あれば）
+  if (authed) {
+    headers.set("access-token", at!);
+    headers.set("client", client!);
+    headers.set("uid", uid!);
+    headers.set("token-type", tokenType);
+    headers.set("Authorization", `${tokenType} ${at}`);
+  }
+
+  // 並行競合用タイムスタンプ（AuthContext と整合してOK）
+  headers.set("x-auth-start", String(Date.now()));
+
+  // FormData のときは Content-Type を外す（ブラウザに任せる）
+  if (typeof FormData !== "undefined" && config.data instanceof FormData) {
+    headers.delete("Content-Type");
+  }
+
+  config.headers = headers;
+  return config;
+});
+
+// ★ レスポンスで新トークンが来たら保存（AuthContext の保存とも競合しない）
+api.interceptors.response.use(
+  (res) => {
+    const h = res.headers;
+    const at = getHeader(h, "access-token");
+    const client = getHeader(h, "client");
+    const uid = getHeader(h, "uid");
+    const tokenType = getHeader(h, "token-type");
+    const expiry = getHeader(h, "expiry");
+
+    if (at && client && uid) {
+      localStorage.setItem("access-token", at);
+      localStorage.setItem("client", client);
+      localStorage.setItem("uid", uid);
+      if (tokenType) localStorage.setItem("token-type", tokenType);
+      if (expiry) localStorage.setItem("expiry", expiry);
+    }
+    return res;
+  },
+  (error) => {
+    // こちらでブロックしただけのケースはそのまま返す
+    if (isCancel(error)) return Promise.reject(error);
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,8 +5,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import { AppRouter } from "./router/AppRouter";
 import { AuthProvider } from "./providers/AuthContext";
-
-// 追加
 import { TaskDrawerProvider } from "./features/drawer/useTaskDrawer";
 import { ToastProvider } from "./components/ToastProvider";
 

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -6,7 +6,7 @@ import Layout from "../components/Layout";
 import RequireAuth from "../components/RequireAuth";
 import Account from "../pages/Account";
 import Help from "../pages/Help";
-import Home from "../pages/Home"; // ★ 追加
+import Home from "../pages/Home";
 
 export const AppRouter = () => {
   return (
@@ -17,17 +17,19 @@ export const AppRouter = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/signin" element={<Navigate to="/login" replace />} />
 
-        {/* 認証ガード配下 */}
+        {/* 認証ガード配下（レイアウトも保護下に置く） */}
         <Route element={<RequireAuth />}>
           <Route element={<Layout />}>
             <Route path="/tasks" element={<TaskList />} />
             <Route path="/account" element={<Account />} />
             <Route path="/help" element={<Help />} />
+            {/* 保護領域内のフォールバックは /tasks */}
+            <Route path="*" element={<Navigate to="/tasks" replace />} />
           </Route>
         </Route>
 
-        {/* その他は tasks へ */}
-        <Route path="*" element={<Navigate to="/tasks" replace />} />
+        {/* ガードの外側のフォールバックは /login（未ログイン時の二段リダイレクト回避） */}
+        <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## 目的
ローカル開発を即時に再現できるよう、Docker Compose で api/db/front を統合。併せて、frontend のローカル環境変数を Git 管理から除外し、テンプレを追加します。

## 変更点
- docker-compose.yml を追加/更新  
  - db: MySQL 8（3306, 永続ボリューム）
  - api: Rails（3000, backend/Dockerfile.dev ベース）
  - front: Vite（5173, frontend/Dockerfile ベース）
- backend
  - Dockerfile.dev: ruby:3.2-slim + MySQL開発用ライブラリ、bundle install、/rails 作業ディレクトリ
  - bin/compose-entrypoint.sh: MySQL待機 → `rails db:prepare` → `rails s -b 0.0.0.0 -p 3000`
- frontend
  - Dockerfile: Node 20 + pnpm(corepack)、開発サーバ（Vite）起動
  - .dockerignore: `dist`, `node_modules` を除外
- 環境変数運用
  - `.gitignore` に `/frontend/.env*.local` を追加（秘密はコミットしない方針）
  - `frontend/.env.example` を追加（テンプレ）

