### PR TITLE
feat(health): 無認証 /up を追加（status/app/sha/rails_env/time/db）

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -67,3 +67,11 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 # Start server via Thruster by default, this can be overwritten at runtime
 EXPOSE 80
 CMD ["./bin/thrust", "./bin/rails", "server"]
+
+# ビルド時に短SHAを埋め込めるように
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
+# コンテナのヘルスチェック（ECS/Fargate でもそのまま有効）
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD curl -fsS http://localhost:3000/up || exit 1

--- a/backend/app/controllers/health_controller.rb
+++ b/backend/app/controllers/health_controller.rb
@@ -1,0 +1,26 @@
+class HealthController < ApplicationController
+    skip_before_action :authenticate_user!, raise: false
+  
+    def show
+      payload = {
+        status: "ok",
+        app: ENV.fetch("APP_NAME", "genba-task-api"),
+        sha: ENV.fetch("GIT_SHA", "unknown"),
+        rails_env: Rails.env,
+        time: Time.now.utc.iso8601,
+        db: db_alive?
+      }
+      response.set_header("Cache-Control", "no-store")
+      render json: payload, status: :ok
+    end
+  
+    private
+  
+    def db_alive?
+      ActiveRecord::Base.connection.execute("SELECT 1")
+      true
+    rescue
+      false
+    end
+  end
+  

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,8 +1,9 @@
 # config/routes.rb
 Rails.application.routes.draw do
+  get "/up", to: "health#show"
   namespace :api do
     mount_devise_token_auth_for 'User', at: 'auth'
-
+    
     get "me", to: "users#me"
 
     resources :tasks do

--- a/backend/spec/requests/health_spec.rb
+++ b/backend/spec/requests/health_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "GET /up", type: :request do
+  it "returns 200 and health json without auth" do
+    get "/up"
+    expect(response).to have_http_status(:ok)
+    json = JSON.parse(response.body)
+    expect(json["status"]).to eq("ok")
+    expect(json).to include("app", "sha", "rails_env", "time", "db")
+  end
+end


### PR DESCRIPTION
# 概要
- 無認証のヘルスチェック `/up` を追加
- Docker コンテナの HEALTHCHECK を設定

# 変更内容
- routes: GET /up
- controller: HealthController#show（status/app/sha/rails_env/time/db）
- spec: Request spec 追加
- Dockerfile: HEALTHCHECK 追加

# 動作確認
- `curl http://localhost:3000/up` が 200 / JSON 返却
- RSpec 緑（/up のキー検証を含む）
- Docker イメージ起動時に HEALTHCHECK が healthy になる

# 影響範囲/リスク
- 公開エンドポイントが1つ増える（機微情報なし）
- 起動直後など DB 未接続時は `db:false` の可能性（ALB はリトライで回復）

# ロールバック
- このPRをrevert

# 補足
- 将来的に `/ready` を分けて DB 依存チェックを移す想定
