### PR TITLE
docs(infra): ALBをHTTPS化(ACM)＋HTTP→HTTPSリダイレクト手順と検証結果を追加

### DIFF
--- a/docs/infra/alb-https-acm.md
+++ b/docs/infra/alb-https-acm.md
@@ -1,0 +1,53 @@
+
+# ALB の HTTPS 化（api.genba-tasks.com）
+
+## 概要
+- 目的: API を HTTPS 提供し、HTTP を 301 で HTTPS にリダイレクトする
+- 対象: genba-task-alb（ap-northeast-1）
+- 証明書: ACM(ap-northeast-1) / `api.genba-tasks.com`（DNS 検証）
+
+## 実施内容
+1. **ACM 証明書発行（東京）**
+   - Domain: `api.genba-tasks.com`
+   - Validation: DNS（Route 53 で CNAME 自動作成）
+   - Status: **Issued**
+
+2. **ALB**
+   - Security Group: 443/TCP を 0.0.0.0/0 に開放
+   - Listener(443/HTTPS): TargetGroup `genba-task-tg` に Forward  
+     Security policy: `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`
+   - Listener(80/HTTP): **HTTPS:443 へ 301 リダイレクト**
+
+3. **Route 53**
+   - Hosted zone: `genba-tasks.com`
+   - A (ALIAS): `api.genba-tasks.com` → **genba-task-alb**（dualstack）
+   - （任意）AAAA (ALIAS): `api.genba-tasks.com` → 同上
+
+## 検証（抜粋）
+```bash
+# HTTP は 301
+curl -I http://api.genba-tasks.com/up
+# => HTTP/1.1 301 ... Location: https://api.genba-tasks.com:443/up
+
+# HTTPS は 200
+curl -I https://api.genba-tasks.com/up
+# => HTTP/2 200
+
+ DoD
+ http://api.genba-tasks.com/up が 301 で https に誘導
+ https://api.genba-tasks.com/up が 200 を返す
+ ACM 証明書 Issued / ALB 443 リスナー稼働 / 80→443 リダイレクト
+
+リスク & 対応
+証明書失効: ACM 自動更新（DNS 検証維持）
+CORS: 後続の独自ドメイン導入時に API 側で https://app.genba-tasks.com を許可
+監視: 5xx 連続時は ALB Target 健康状態と ECS ログを確認
+
+ロールバック
+一時的に HTTP を許可: 80 のデフォルトアクションを genba-task-tg Forward に変更
+DNS 戻し: A(ALIAS) を ALB 以外に切替（必要時）
+
+参考
+ACM ARN: （ACM 画面参照）
+ALB: genba-task-alb
+Target Group: genba-task-tg


### PR DESCRIPTION
## 概要
API を `api.genba-tasks.com` で HTTPS 提供。HTTP(80) は 301 で HTTPS(443) に恒久リダイレクトしました。

## 変更点
- ACM(ap-northeast-1): `api.genba-tasks.com` 証明書を DNS 検証で発行（Status: **Issued**）
- ALB(genba-task-alb):
  - 443/HTTPS リスナー → TargetGroup `genba-task-tg` に Forward
  - 80/HTTP リスナー → **HTTPS:443 に 301 Redirect**
  - Security policy: `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`
- セキュリティグループ: 443/TCP を開放
- Route 53(hosted zone: genba-tasks.com):
  - A(ALIAS) `api.genba-tasks.com` → ALB（dualstack）
- ドキュメント: `docs/infra/alb-https-acm.md` を追加（手順・検証結果・ロールバック記載）

## 背景 / 目的
- 本番運用で HTTPS を前提にするため（SEO / セキュリティ / HSTS）
- HTTP アクセスは恒久的に HTTPS へ誘導し、混在コンテンツを排除

## 動作確認
```bash
curl -I http://api.genba-tasks.com/up   # => 301 Location: https://api.genba-tasks.com:443/up
curl -I https://api.genba-tasks.com/up  # => 200

Doneの定義
 HTTP→HTTPS リダイレクト（301）を確認
 HTTPS エンドポイントで 200 を確認
 証明書 Issued / リスナー反映 / DNS 反映済み

リスク・対応
証明書更新失敗: DNS 検証(CNAME)を維持し ACM の自動更新に依存

CORS 設定: 次PR（dns/custom-domains）で https://app.genba-tasks.com を API 側に許可

一時回避策: 80 リスナーを Forward に戻せば HTTP 直接利用も可


ロールバック
80 リスナーのデフォルトアクションを Forward に変更
必要に応じて A(ALIAS) を切り戻し

備考
CloudFront/フロントの独自ドメイン対応は次PR（dns/custom-domains）で実施
